### PR TITLE
add bunch charge from nml (PWFA - version)

### DIFF
--- a/src/control_bunch_input.f90
+++ b/src/control_bunch_input.f90
@@ -34,7 +34,7 @@
 
  real(dp) :: bunch_charge(5),bunch_volume(5),jb_norm(5),reduced_charge(5),Lorentz_bfact(5)
  real(dp) :: Charge_right(5), Charge_left(5)
- real(dp) :: gam(5),rhob(5)
+ real(dp) :: gam(5),rhob(5), particle_charge(5)
  real(dp) :: xc_bunch(5),yc_bunch(5),zc_bunch(5)
  real(dp) :: sxb(5),syb(5)
  real(dp) :: epsy(5),epsz(5),dg(5)

--- a/src/pic_in.f90
+++ b/src/pic_in.f90
@@ -721,7 +721,7 @@
  !==================
 !=====================
  !Resets nptx(ic)=last particle coordinate inside the computational box
- !in the initial condition: for t>0  nptx(ic) updated by mowing window 
+ !in the initial condition: for t>0  nptx(ic) updated by mowing window
  do ic=1,nsp
   i1=0
   do j=1,nptx(ic)
@@ -1268,11 +1268,11 @@
  loc_imax(imodx,1:6)=nptx_loc(1:6)
  nps_loc=0
  !Weights for multilayer multisp targets
- wgh_sp(1)=1./real(mp_per_cell(3),dp)                   
+ wgh_sp(1)=1./real(mp_per_cell(3),dp)
  wgh_sp(2)=1./(real(ion_min(2),dp)*real(mp_per_cell(4),dp))
  wgh_sp(3)= j0_norm
  wgh_sp(4)=1./(real(ion_min(1),dp)*real(mp_per_cell(2),dp))
- wgh_sp(5)=1./real(mp_per_cell(5),dp)                   
+ wgh_sp(5)=1./real(mp_per_cell(5),dp)
  wgh_sp(6)=1./(real(ion_min(2),dp)*real(mp_per_cell(6),dp))
  !================================================
  if(nxl(1) >0)then
@@ -1323,7 +1323,7 @@
   end do
  end do
  !================================
- ! WARNING : electrons and Z1 ions have the same weight 
+ ! WARNING : electrons and Z1 ions have the same weight
  ! if mp_per_cell(1)=Z1*mp_per_cell(2)
  !=================================
  xfsh=xfsh+lpx(3)+lpx(2)
@@ -1576,7 +1576,7 @@
  !============ nptx(nsp)  distribution
  nptx(1)=nptx_loc(1)+nptx_loc(3)+nptx_loc(6)  !electrons
  nptx(2)=nptx_loc(4)                          !Z1-A1 species
- nptx(3)=nptx_loc(5)                          !Z2-A2 species 
+ nptx(3)=nptx_loc(5)                          !Z2-A2 species
  nptx(4)=nptx_loc(2)+nptx_loc(6)              !Z3-A3  species in nxl(1) and nxl(5) layer
  nptx_max=maxval(nptx_loc(1:7))
  !=======================
@@ -2512,7 +2512,7 @@
   !lpx(4) second plateau density np2 and to final downramp lpx(5)
   !n_0=n_over_nc can be an average, or n0_=n1_over_nc or n0_=n2_over_nc
   !Multispecies implementation
-  ! target in models id=1 and id=2 contain (implicitely) an ion species id_sp=1 
+  ! target in models id=1 and id=2 contain (implicitely) an ion species id_sp=1
   !as a neutralizing background. If ionization is on, nsp=2 and ionizing species
   !is loaded and activated for ionization.
   !====================================
@@ -2520,7 +2520,7 @@
   !as a neutralizing background:
   ! layer(1) + layer(2) only electrons and H+ with ne=n0=n_over_nc
   ! layer(3) is a plateau with an added dopant (A1,Z1) with density
-  ! np1=n1_over_n/n0 (few %) 
+  ! np1=n1_over_n/n0 (few %)
   ! layer(4)+layer(5) as layer(1)+layer(2)
   !----------
  else
@@ -2665,7 +2665,7 @@
  integer,intent(in) :: lp_mod
  integer :: ic,i1,i2,j1,j2,k1,k2,lp_ind
  real(dp) :: angle,shx_lp,sigm,eps,xm,tt,tau,tau1
- 
+
 
  !===========================
  ! field grid index defined on set_pgrid
@@ -2726,14 +2726,14 @@
  if(Two_color)then
   xc1_lp=xc_loc(nb_laser)-lp_offset
   xf1=xc1_lp+t1_lp
-  
+
   lp_ionz_in=xc1_lp-tau1
   lp_ionz_end=xc1_lp+tau1
   call init_lp_inc0_fields(ebf,lp1_amp,tt,t1_lp,w1_x,w1_y,xf1,om1,&
                                               lp_ind,i1,i2)
   if(pe0)write(6,'(a30,e11.4)')'two-color activated at xc1_lp=',xc1_lp
- endif 
-  
+ endif
+
 !==================================
  !==================== inject particles
  if(Hybrid)then
@@ -2850,7 +2850,7 @@
   env1(:,:,:,:)=0.0
   xc1_lp=xc_loc(nb_laser)-lp_offset
   xf1=xc1_lp+t1_lp
-   
+
   lp_ionz_in=xc1_lp-tau1
   lp_ionz_end=xc1_lp+tau1
   if(lp_ionz_end > xm)then
@@ -2861,7 +2861,7 @@
     call init_envelope_field(&
               env1,a1,dt,tt,t1_lp,w1_x,w1_y,xf1,om1,i1,i2)
    endif
-  endif 
+  endif
  endif
  !=======================
  !==========================
@@ -2950,14 +2950,14 @@
    wgh=real(j0_norm*jb_norm(ip),sp) !the bunch particles weights
    i2=i1+nb_tot(ip)-1
 
-      if(bunch_shape(ip)==1 .and. ppc_bunch(ip,1)>0) & !weighted-option
+   if(bunch_shape(ip)==1 .and. ppc_bunch(ip,1)>0) & !weighted-option
                           call generate_bunch_bigaussian_weighted(i1,i2,&
                                sxb(ip),xc_bunch(ip),&
                                syb(ip),yc_bunch(ip),&
                                syb(ip),zc_bunch(ip),&
                                gam(ip),&
                                epsy(ip),epsz(ip),sigma_cut_bunch(ip),&
-                               dg(ip),bpart,dx,dy,dz,rhob(ip),ppc_bunch(ip,:))
+                               dg(ip),bpart,dx,dy,dz,rhob(ip),ppc_bunch(ip,:), particle_charge(ip))
    if(bunch_shape(ip)==1 .and. ppc_bunch(ip,1)==-1) & !equal-weight
                           call generate_bunch_bigaussian_equal(i1,i2,&
                                sxb(ip),xc_bunch(ip),&
@@ -2965,33 +2965,33 @@
                                syb(ip),zc_bunch(ip),&
                                gam(ip),&
                               epsy(ip),epsz(ip),sigma_cut_bunch(ip),&
-                              dg(ip),bpart,dx,dy,dz,rhob(ip))
+                              dg(ip),bpart,dx,dy,dz,rhob(ip), particle_charge(ip))
    if(bunch_shape(ip)==2 .and. ppc_bunch(ip,1)>0) & !weighted-option
                           call generate_bunch_triangularZ_uniformR_weighted(i1,i2,&
                                xc_bunch(ip),yc_bunch(ip),zc_bunch(ip),&
                                sxb(ip),syb(ip),syb(ip),gam(ip),&
                                epsy(ip),epsz(ip),sigma_cut_bunch(ip),dg(ip),&
                                bpart,Charge_right(ip),Charge_left(ip),dx,dy,dz, &
-                               ppc_bunch(ip,1:3))
+                               ppc_bunch(ip,1:3), particle_charge(ip))
    if(bunch_shape(ip)==2 .and. ppc_bunch(ip,1)==-1) & !equal-weight
                            call generate_bunch_triangularZ_uniformR_equal(i1,i2,&
                                 xc_bunch(ip),yc_bunch(ip),zc_bunch(ip),&
                                 sxb(ip),syb(ip),syb(ip),gam(ip),&
                                 epsy(ip),epsz(ip),sigma_cut_bunch(ip),dg(ip),&
-                                bpart,Charge_right(ip),Charge_left(ip))
+                                bpart,Charge_right(ip),Charge_left(ip), particle_charge(ip))
    if(bunch_shape(ip)==3 .and. ppc_bunch(ip,1)>0) & !weighted-option
                            call generate_bunch_triangularZ_normalR_weighted(i1,i2,&
                                 xc_bunch(ip),yc_bunch(ip),zc_bunch(ip),&
                                 sxb(ip),syb(ip),syb(ip),&
                                 gam(ip),epsy(ip),epsz(ip),sigma_cut_bunch(ip),dg(ip),&
                                 bpart,Charge_right(ip),Charge_left(ip),dx,dy,dz, &
-                                ppc_bunch(ip,1:3))
+                                ppc_bunch(ip,1:3), particle_charge(ip))
    if(bunch_shape(ip)==3 .and. ppc_bunch(ip,1)==-1) & !equal-weight
                            call generate_bunch_triangularZ_normalR_equal(i1,i2,&
                                 xc_bunch(ip),yc_bunch(ip),zc_bunch(ip),&
                                 sxb(ip),syb(ip),syb(ip),&
                                 gam(ip),epsy(ip),epsz(ip),sigma_cut_bunch(ip),dg(ip),&
-                                bpart,Charge_right(ip),Charge_left(ip))
+                                bpart,Charge_right(ip),Charge_left(ip), particle_charge(ip))
 
     !--- Twiss Rotation ---!
     if(L_TWISS(ip)) call bunch_twissrotation(i1,i2,bpart, &
@@ -3015,7 +3015,7 @@
  end subroutine beam_data
  !===================
  subroutine MPI_beam_distribute(ndm)
- 
+
  integer,intent(in) :: ndm
 
  integer :: i,ii,i1,j
@@ -3260,7 +3260,7 @@
  if(ndim==3)call FFT_Psolv(jc,gam2,ompe,nx,nx_loc,ny,ny_loc,nz,nz_loc,&
                 i1,i2b,j1,nyp,k1,nzp,ft_mod,ft_sym)
  !Solves Laplacian[pot]=ompe*rho
- !Beam potential in jc(1) 
+ !Beam potential in jc(1)
  !===================
  !====================
  call fill_ebfield_yzxbdsdata(jc,i1,i2b,j1,nyp,k1,nzp,1,2,1,1)

--- a/src/read_input.f90
+++ b/src/read_input.f90
@@ -167,7 +167,8 @@
  !--- *** namelist *** ---!
  NAMELIST/NUMBER_BUNCHES/ n_bunches, L_particles, L_intdiagnostics_pwfa, &
   L_intdiagnostics_classic,L_EMBunchEvolution,number_of_slices
- NAMELIST/BUNCHES/nb_tot,bunch_type,bunch_shape,rhob,xc_bunch,yc_bunch,zc_bunch, &
+ NAMELIST/BUNCHES/nb_tot,bunch_type,bunch_shape,particle_charge,rhob, &
+  xc_bunch,yc_bunch,zc_bunch, &
   gam,sxb,syb,epsy,epsz,dg,Charge_right,Charge_left,sigma_cut_bunch, &
   ppc_x_bunch,ppc_y_bunch,ppc_z_bunch
 
@@ -193,6 +194,7 @@
  !shape 2: trapezoidal (linear in Z, uniform with cutoff in R)
  !shape 3: trapezoidal-gaussian (linear in Z, gaussian in R)
  !shape 4: cylinder
+ particle_charge = -1.
  rhob=1.0 !relative density n_bunch/n_plasmabackground
  Charge_right=-1.0
  Charge_left =-1.0

--- a/src/util.f90
+++ b/src/util.f90
@@ -773,10 +773,10 @@
 
  !---*** BIGAUSSIAN bunch, same number of particle per cell :: different weights ***---!
  subroutine generate_bunch_bigaussian_weighted( &
-  n1,n2,s_x,x_cm,s_y,y_cm,s_z,z_cm,gm,eps_y,eps_z,sigma_cut,dg,bunch,dx,dy,dz,alpha,ppcb)
+  n1,n2,s_x,x_cm,s_y,y_cm,s_z,z_cm,gm,eps_y,eps_z,sigma_cut,dg,bunch,dx,dy,dz,alpha,ppcb,particle_unit_charge)
  integer,intent(in) :: n1,n2,ppcb(3)
  real(dp),intent(in) :: s_x,s_y,s_z,gm,eps_y,eps_z,sigma_cut,dg,alpha
- real(dp),intent(in) :: x_cm,y_cm,z_cm,dx,dy,dz
+ real(dp),intent(in) :: x_cm,y_cm,z_cm,dx,dy,dz,particle_unit_charge
  real(dp),intent(inout) :: bunch(:,:)
  integer :: i,j,np,effecitve_cell_number,npart,npart_x,npart_y,npart_z,npart_tot,idx,ix,iy,iz
  real(dp) :: sigs(6),rnumber(n2-n1+1)
@@ -813,7 +813,7 @@
                wgh = wgh*exp(-(x-x_cm)**2/2./s_x**2)
                wgh = wgh*exp(-(y-y_cm)**2/2./s_y**2)
                wgh = wgh*exp(-(z-z_cm)**2/2./s_z**2)
-               charge = int(unit_charge(1), hp_int)
+               charge = int(particle_unit_charge*-1.*unit_charge(1), hp_int)
                bunch(7,idx)=wgh_cmp
                idx=idx+1
              enddo
@@ -833,12 +833,13 @@
 
 !---*** BIGAUSSIAN bunch particle with the SAME WEIGHT ***---!
 subroutine generate_bunch_bigaussian_equal( &
- n1,n2,s_x,x_cm,s_y,y_cm,s_z,z_cm,gm,eps_y,eps_z,sigma_cut,dg,bunch,dx,dy,dz,alpha)
+ n1,n2,s_x,x_cm,s_y,y_cm,s_z,z_cm,gm,eps_y,eps_z,sigma_cut,dg,bunch,dx,dy,dz,alpha,particle_unit_charge)
 integer,intent(in) :: n1,n2
 real(dp),intent(in) :: s_x,s_y,s_z,gm,eps_y,eps_z,dg,alpha,sigma_cut
-real(dp),intent(in) :: x_cm,y_cm,z_cm,dx,dy,dz
+real(dp),intent(in) :: x_cm,y_cm,z_cm,dx,dy,dz,particle_unit_charge
 real(dp),intent(inout) :: bunch(:,:)
 real(dp) :: rnumber(n2-n1+1)
+integer :: npart
 
     call boxmuller_vector_cut(rnumber,n2-n1+1,sigma_cut)
     bunch(1,n1:n2)=rnumber*s_x + x_cm
@@ -853,15 +854,20 @@ real(dp) :: rnumber(n2-n1+1)
     call boxmuller_vector(rnumber,n2-n1+1)
     bunch(6,n1:n2)=rnumber*eps_z/s_z
     bunch(7,n1:n2)=wgh_cmp
+    do npart=n1,n2
+      charge = int(particle_unit_charge*-1.*unit_charge(1), hp_int)
+      bunch(7,npart)=wgh_cmp
+    enddo
+
 end subroutine generate_bunch_bigaussian_equal
 
  !---*** TRIANGULAR-UNIFORM_R bunch, same number of particle per cell :: different weights ***---!
  subroutine generate_bunch_triangularZ_uniformR_weighted(n1,n2,x_cm,y_cm,z_cm,s_x,s_y,s_z,&
-  gamma_m,eps_y,eps_z,sigma_cut,dgamma,bunch,Charge_right,Charge_left,dx,dy,dz,ppcb)
+  gamma_m,eps_y,eps_z,sigma_cut,dgamma,bunch,Charge_right,Charge_left,dx,dy,dz,ppcb,particle_unit_charge)
  integer,intent(in)   :: n1,n2,ppcb(3)
  real(dp),intent(in)    :: x_cm,y_cm,z_cm,dx,dy,dz,sigma_cut
  real(dp),intent(in)    :: s_x,s_y,s_z,gamma_m,eps_y,eps_z,dgamma
- real(dp),intent(in)    :: Charge_right,Charge_left
+ real(dp),intent(in)    :: Charge_right,Charge_left,particle_unit_charge
  real(dp),intent(inout)   :: bunch(:,:)
  real(dp) :: rnumber(n2-n1+1)
  integer :: i,cells,ix,iy,iz,idx,npart,npart_x,npart_y,npart_z,npart_tot,effecitve_cell_number
@@ -895,7 +901,7 @@ idx=n1
            bunch(2,idx)=y
            bunch(3,idx)=z
            wgh=one_sp/real(PRODUCT(ppcb)*(Charge_left+(Charge_right-Charge_left)/s_x*(x+s_x-x_cm)),sp)
-           charge = int(unit_charge(1), hp_int)
+           charge = int(particle_unit_charge*-1.*unit_charge(1), hp_int)
            bunch(7,idx)=wgh_cmp
            idx=idx+1
          enddo
@@ -916,14 +922,14 @@ idx=n1
  !---*** TRIANGULAR-UNIFORM_R bunch, all particle SAME WEIGHT ***---!
  subroutine generate_bunch_triangularZ_uniformR_equal( &
    n1,n2,x_cm,y_cm,z_cm,s_x,s_y,s_z,&
-   gamma_m,eps_y,eps_z,sigma_cut,dgamma,bunch,Charge_right,Charge_left)
+   gamma_m,eps_y,eps_z,sigma_cut,dgamma,bunch,Charge_right,Charge_left,particle_unit_charge)
  integer,intent(in)   :: n1,n2
  real(dp),intent(in)    :: x_cm,y_cm,z_cm,sigma_cut
  real(dp),intent(in)    :: s_x,s_y,s_z,gamma_m,eps_y,eps_z,dgamma
- real(dp),intent(in)    :: Charge_right,Charge_left
+ real(dp),intent(in)    :: Charge_right,Charge_left,particle_unit_charge
  real(dp),intent(inout)   :: bunch(:,:)
  real(dp) :: rnumber(n2-n1+1)
- integer :: i
+ integer :: i, npart
  real(dp) :: z,y,x,a,intercept,slope
 
   do i=n1,n2+1
@@ -954,17 +960,21 @@ idx=n1
    call boxmuller_vector(rnumber,n2-n1+1)
    bunch(6,n1:n2)=rnumber*2.*eps_z/s_z
    bunch(7,n1:n2)=wgh_cmp
+   do npart=n1,n2
+     charge = int(particle_unit_charge*-1.*unit_charge(1), hp_int)
+     bunch(7,npart)=wgh_cmp
+   enddo
  end subroutine generate_bunch_triangularZ_uniformR_equal
 
 
  !--- *** triangular in Z and normal-gaussian disttributed in the transverse directions *** ---!
  !--- *** option with different WEIGHTS *** ---!
  subroutine generate_bunch_triangularZ_normalR_weighted(n1,n2,x_cm,y_cm,z_cm,s_x,s_y,s_z,&
-  gamma_m,eps_y,eps_z,sigma_cut,dgamma,bunch,Charge_right,Charge_left,dx,dy,dz,ppcb)
+  gamma_m,eps_y,eps_z,sigma_cut,dgamma,bunch,Charge_right,Charge_left,dx,dy,dz,ppcb,particle_unit_charge)
  integer,intent(in)   :: n1,n2,ppcb(3)
  real(dp),intent(in)    :: x_cm,y_cm,z_cm,dx,dy,dz,sigma_cut
  real(dp),intent(in)    :: s_x,s_y,s_z,gamma_m,eps_y,eps_z,dgamma
- real(dp),intent(in)    :: Charge_right,Charge_left
+ real(dp),intent(in)    :: Charge_right,Charge_left,particle_unit_charge
  real(dp),intent(inout)   :: bunch(:,:)
  real(dp) :: rnumber(n2-n1+1)
  integer :: i,ix,iy,iz,effecitve_cell_number,idx,npart,npart_x,npart_y,npart_z,npart_tot
@@ -999,7 +1009,7 @@ idx=n1
             wgh = one_sp/PRODUCT(ppcb)
             wgh = wgh*real((Charge_left+(Charge_right-Charge_left)/s_x*(x+s_x-x_cm)),sp)
             wgh = wgh*real(exp(-((y-y_cm)**2+(z-z_cm)**2)/2./s_y**2),sp)
-            charge = int(unit_charge(1), hp_int)
+            charge = int(particle_unit_charge*-1.*unit_charge(1), hp_int)
             bunch(7,idx)=wgh_cmp
             idx=idx+1
           enddo
@@ -1020,14 +1030,14 @@ idx=n1
 !--- *** triangular in Z and normal-gaussian disttributed in the transverse directions *** ---!
 !--- *** particle have the SAME WEIGHTS *** ---!
 subroutine generate_bunch_triangularZ_normalR_equal(n1,n2,x_cm,y_cm,z_cm,s_x,s_y,s_z,&
-    gamma_m,eps_y,eps_z,sigma_cut,dgamma,bunch,Charge_right,Charge_left)
+    gamma_m,eps_y,eps_z,sigma_cut,dgamma,bunch,Charge_right,Charge_left,particle_unit_charge)
   integer,intent(in)   :: n1,n2
   real(dp),intent(in)  :: x_cm,y_cm,z_cm,sigma_cut
   real(dp),intent(in)  :: s_x,s_y,s_z,gamma_m,eps_y,eps_z,dgamma
-  real(dp),intent(in)  :: Charge_right,Charge_left
+  real(dp),intent(in)  :: Charge_right,Charge_left,particle_unit_charge
   real(dp),intent(inout) :: bunch(:,:)
   real(dp) :: rnumber(n2-n1+1)
-  integer :: i
+  integer :: i, npart
   real(dp) :: z,y,x,a,intercept,slope
 
   do i=n1,n2+1
@@ -1053,6 +1063,10 @@ subroutine generate_bunch_triangularZ_normalR_equal(n1,n2,x_cm,y_cm,z_cm,s_x,s_y
   call boxmuller_vector(rnumber,n2-n1+1)
   bunch(6,n1:n2)=rnumber*eps_z/s_z
   bunch(7,n1:n2)=wgh_cmp
+  do npart=n1,n2
+    charge = int(particle_unit_charge*-1.*unit_charge(1), hp_int)
+    bunch(7,npart)=wgh_cmp
+  enddo
  end subroutine generate_bunch_triangularZ_normalR_equal
 
 


### PR DESCRIPTION
The option _particle_charge_ has been added to the _nml_, *BUNCHES*. Example: -1 for an electron bunch, +1 for a positron bunch.