### PR TITLE
Fixed interpolation in envelope

### DIFF
--- a/src/particles.F90
+++ b/src/particles.F90
@@ -3029,7 +3029,7 @@
    sx2=sx*sx
    ayh(1)=0.75-sx2
    ayh(2)=0.5*(0.25+sx2+sx)
-   ayh(0)=1.-axh(1)-axh(2)
+   ayh(0)=1.-ayh(1)-ayh(2)
 
    !ayh(1)=sx+0.5
    !ayh(0)=1.-ayh(1)
@@ -3047,7 +3047,7 @@
    sx2=sx*sx
    azh(1)=0.75-sx2
    azh(2)=0.5*(0.25+sx2+sx)
-   azh(0)=1.-axh(1)-axh(2)
+   azh(0)=1.-azh(1)-azh(2)
 
    !azh(1)=sx+0.5
    !azh(0)=1.-azh(1)


### PR DESCRIPTION
The interpolation for envelope have been fixed in the dev/titoiride/plasmachannel branch, waiting for the PR merging. It is presented in a separated branch so that it can be implemented immediately.