### PR TITLE
Introduce mpi_write and mpi_read for a better synchronization when doing massive data dump

### DIFF
--- a/scripts/build/cmake.mac
+++ b/scripts/build/cmake.mac
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-export CC=/usr/local/bin/gcc-8
-export CXX=/usr/local/bin/g++-8
 export FC=/usr/local/bin/gfortran-8
 
 mkdir -p build ; cd build
-cmake .. -DCMAKE_Fortran_COMPILER=$FC
+cmake .. -DCMAKE_BUILD_TYPE="Release" -DCMAKE_Fortran_COMPILER=$FC
 cmake --build . --target install
 cd ..

--- a/scripts/build/cmake.mac.debug
+++ b/scripts/build/cmake.mac.debug
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-export CC=/usr/local/bin/gcc-8
-export CXX=/usr/local/bin/g++-8
 export FC=/usr/local/bin/gfortran-8
 
 mkdir -p build ; cd build

--- a/src/ALaDyn.F90
+++ b/src/ALaDyn.F90
@@ -674,7 +674,7 @@
  end select
 !===================
   if(Pe0)then
-   write(6,*)'time step resetting:' 
+   write(6,*)'time step resetting:'
    write(6,*)'  new ',dt_loc,'  old ',dt
    write(6,*)'tot iterations ',iter_max
    write(6,*)'tot time ',iter_max*dt_loc

--- a/src/all_param.f90
+++ b/src/all_param.f90
@@ -544,10 +544,10 @@
     if(bunch_shape(i)==1 .and. nb_tot(i)==-1) then
       jb_norm(i)=1.0_dp/(PRODUCT(ppc_bunch(i,:))*j0_norm)
     endif
-    if(bunch_shape(i)==2 .and. nb_tot(i)>  0) then 
+    if(bunch_shape(i)==2 .and. nb_tot(i)>  0) then
       jb_norm(i)=(Charge_left(i)+Charge_right(i))/2.0*gvol_inv*bunch_volume(i)/(nb_tot(i)*j0_norm)
     endif
-    if(bunch_shape(i)==1 .and. nb_tot(i)==-1) then 
+    if(bunch_shape(i)==1 .and. nb_tot(i)==-1) then
       jb_norm(i)=1.0_dp/(PRODUCT(ppc_bunch(i,:))*j0_norm)
     endif
     if(bunch_shape(i)==3 .and. nb_tot(i)>  0) then
@@ -556,10 +556,10 @@
     if(bunch_shape(i)==3 .and. nb_tot(i)==-1) then
       jb_norm(i)=1.0_dp/(PRODUCT(ppc_bunch(i,:))*j0_norm)
     endif
-    if(bunch_shape(i)==4 .and. nb_tot(i)>  0) then 
+    if(bunch_shape(i)==4 .and. nb_tot(i)>  0) then
       jb_norm(i)=rhob(i)*gvol_inv*bunch_volume(i)/(nb_tot(i)*j0_norm)
     endif
-    if(bunch_shape(i)==1 .and. nb_tot(i)==-1) then 
+    if(bunch_shape(i)==1 .and. nb_tot(i)==-1) then
       jb_norm(i)=1.0_dp/(PRODUCT(ppc_bunch(i,:))*j0_norm)
     endif
    end do

--- a/src/code_util.f90
+++ b/src/code_util.f90
@@ -26,7 +26,7 @@
  implicit none
 
  integer,parameter :: major_version = 7
- integer,parameter :: minor_version = 1
+ integer,parameter :: minor_version = 2
  character(6) :: sw_name='ALaDyn'
  character(9) :: input_namelist_filename='input.nml'
  character(10) :: input_data_filename='input.data'

--- a/src/der_lib.f90
+++ b/src/der_lib.f90
@@ -61,9 +61,9 @@
   cmp_coeff(2)=(1.-cmp_coeff(1))/3.     !-(1-nu*nu)/24
   opt_der2= -(1.-nu*nu)/12.
   hord_der2= opt_der2
-  !For der_rder=3 opt second derivative 
+  !For der_rder=3 opt second derivative
   opt_der1= (4.-nu*nu)/3.
-  !For der_rder=3 opt for centered first derivative 
+  !For der_rder=3 opt for centered first derivative
   !=========================
   avg_cmp=1./(cmp_coeff(1)+cmp_coeff(2))
   aph_der=cmp_coeff(2)*avg_cmp

--- a/src/fstruct_data.f90
+++ b/src/fstruct_data.f90
@@ -165,10 +165,12 @@
  allocate(up(n1p,n2p,n3p,fcomp),STAT=AllocStatus)
  allocate(up0(n1p,n2p,n3p,fcomp),STAT=AllocStatus)
  allocate(flux(n1p,n2p,n3p,flcomp),STAT=AllocStatus)
+ allocate(fluid_yz_profile(n2p,n3p),STAT=AllocStatus)
  up=0.0
  flux=0.0
  up0=0.0
- fsize=fsize+ng*(2*fcomp+flcomp)
+ fluid_yz_profile=0.0
+ fsize=fsize+ng*(2*fcomp+flcomp) +n2p*n3p
  if(lp >2)then
   allocate(up1(n1p,n2p,n3p,fcomp),STAT=AllocStatus)
   up1=0.0

--- a/src/fstruct_data.f90
+++ b/src/fstruct_data.f90
@@ -48,10 +48,10 @@
  !==============
  ! ns =nsp for active ionization
  !======================
- !extended grid [1:n1+3]  interior [ihx,n1]  
+ !extended grid [1:n1+3]  interior [ihx,n1]
  !overlapping grid [n1-1,n1+ihx]=> 1,ihx+2  [1,2] <= [n1-1,n1],[ihx,ihx+2]=>[n1+1,n1+3]
- 
- n1p=n1+ihx          
+
+ n1p=n1+ihx
  n2p=n2+ihx
  n3p=n3
  ng0=1+(n1-2)*(n2-2)

--- a/src/grid_fields.f90
+++ b/src/grid_fields.f90
@@ -4446,7 +4446,7 @@
  cf(0)=0.0
  cf(1)=1.
  cf(2)=-2.
- if(dord > 2)then              ! dord=3  se_coeff(2)=-(1-nu*nu)/8  dord=4 se_coeff(2)=-1/8    
+ if(dord > 2)then              ! dord=3  se_coeff(2)=-(1-nu*nu)/8  dord=4 se_coeff(2)=-1/8
   cf(0)=hord_der2
   cf(1)=1.-4.*hord_der2
   cf(2)=6.*hord_der2-2.

--- a/src/parallel.F90
+++ b/src/parallel.F90
@@ -32,7 +32,7 @@
  include 'mpif.h'
 
 
- integer, parameter :: offset_kind = MPI_OFFSET_KIND
+ integer, parameter :: offset_kind = MPI_OFFSET_KIND,whence = MPI_SEEK_SET
 
  integer :: mpi_err
  integer,allocatable :: loc_npart(:,:,:,:),loc_nbpart(:,:,:,:)

--- a/src/parallel.F90
+++ b/src/parallel.F90
@@ -49,6 +49,7 @@
  integer :: comm,status(mpi_status_size),error,mpi_sd
  logical :: pex0,pex1
  integer :: coor(3),comm_col(3),color(3)
+ integer, allocatable :: single_communicator(:)
 
  contains
 
@@ -82,6 +83,9 @@
  call mpi_init(error)
  call mpi_comm_size(mpi_comm_world,mpi_size,error)
  call mpi_comm_rank(mpi_comm_world,mpi_rank,error)
+ allocate(single_communicator(mpi_size))
+
+ call mpi_comm_split(mpi_comm_world,mpi_rank,mpi_rank,single_communicator,error)
 
  call check_decomposition
 
@@ -288,6 +292,30 @@
  call mpi_file_close(thefile, ierr)
 
  end subroutine mpi_write_part_col
+ !========================
+ subroutine mpi_write_dump_real(buf,bufsize,thefile)
+
+ real(sp),intent(in) :: buf(:)
+ integer,intent(in) :: bufsize, thefile
+
+ integer :: ierr
+
+ call mpi_file_write(thefile, buf, bufsize, mpi_real, &
+  mpi_status_ignore, ierr)
+
+ end subroutine mpi_write_dump_real
+ !========================
+ subroutine mpi_write_dump_int(buf,bufsize,thefile)
+
+ real(sp),intent(in) :: buf(:)
+ integer,intent(in) :: bufsize, thefile
+
+ integer :: ierr
+
+ call mpi_file_write(thefile, buf, bufsize, mpi_integer, &
+  mpi_status_ignore, ierr)
+
+ end subroutine mpi_write_dump_int
  !========================
  subroutine mpi_write_field(buf,bufsize,header,header_size,disp,nchar,fout)
 

--- a/src/parallel.F90
+++ b/src/parallel.F90
@@ -49,7 +49,6 @@
  integer :: comm,status(mpi_status_size),error,mpi_sd
  logical :: pex0,pex1
  integer :: coor(3),comm_col(3),color(3)
- integer, allocatable :: single_communicator(:)
 
  contains
 
@@ -83,9 +82,6 @@
  call mpi_init(error)
  call mpi_comm_size(mpi_comm_world,mpi_size,error)
  call mpi_comm_rank(mpi_comm_world,mpi_rank,error)
- allocate(single_communicator(mpi_size))
-
- call mpi_comm_split(mpi_comm_world,mpi_rank,mpi_rank,single_communicator,error)
 
  call check_decomposition
 
@@ -240,7 +236,118 @@
  end subroutine mpi_valloc
 
  !========================
+  subroutine mpi_write_dp(buf,bufsize,disp,nchar,fout)
 
+ real(dp),intent(in) :: buf(:)
+ integer,intent(in) :: bufsize,nchar
+ integer(offset_kind),intent(in) :: disp
+ character(nchar),intent(in) :: fout
+
+ integer :: ierr,thefile
+
+ call mpi_file_open(comm, fout, &
+  mpi_mode_wronly + mpi_mode_create, &
+  mpi_INFO_NULL,thefile,ierr)
+!======== each process acces thefile and writes at disp(byte) coordinate
+
+ call mpi_file_write_at(thefile, disp,buf, bufsize, mpi_sd, &
+                mpi_status_ignore, ierr)
+ call mpi_file_close(thefile, ierr)
+
+ end subroutine mpi_write_dp
+!========================
+ subroutine mpi_write_row_dp(buf,bufsize,disp,nchar,fout)
+
+ real(dp),intent(in) :: buf(:)
+ integer,intent(in) :: bufsize,nchar
+ integer(offset_kind),intent(in) :: disp
+ character(nchar),intent(in) :: fout
+
+ integer :: ierr,thefile
+
+ call mpi_file_open(comm_col(2), fout, &
+  mpi_mode_wronly + mpi_mode_create, &
+  mpi_INFO_NULL,thefile,ierr)
+                !call mpi_file_set_view(thefile, disp, mpi_sd, &
+                ! mpi_sd, 'native', &
+                !mpi_info_null, ierr)
+
+ call mpi_file_write_at(thefile, disp,buf, bufsize, mpi_sd, &
+  mpi_status_ignore, ierr)
+
+ call mpi_file_close(thefile, ierr)
+ end subroutine mpi_write_row_dp
+!===================
+ subroutine mpi_write_col_dp(buf,bufsize,disp,nchar,fout)
+
+ real(dp),intent(in) :: buf(:)
+ integer,intent(in) :: bufsize,nchar
+ integer(offset_kind),intent(in) :: disp
+ character(nchar),intent(in) :: fout
+
+ integer :: ierr,thefile
+
+ call mpi_file_open(comm_col(1), fout, &
+  mpi_mode_wronly + mpi_mode_create, &
+  mpi_INFO_NULL,thefile,ierr)
+
+ !call mpi_file_set_view(thefile, disp, mpi_sd, &
+ ! mpi_sd, 'native', &
+ ! mpi_info_null, ierr)
+
+ call mpi_file_write_at(thefile, disp,buf, bufsize, mpi_double_precision, &
+  mpi_status_ignore, ierr)
+ 
+ call mpi_file_close(thefile, ierr)
+
+ end subroutine mpi_write_col_dp
+!========================
+ subroutine mpi_read_col_dp(buf,bufsize,disp,nchar,fout)
+
+ real(dp),intent(inout) :: buf(:)
+ integer,intent(in) :: bufsize,nchar
+ integer(offset_kind),intent(in) :: disp
+ character(nchar),intent(in) :: fout
+
+ integer :: ierr,thefile
+
+ call mpi_file_open(comm_col(1), fout, &
+  mpi_mode_rdonly, &
+  mpi_INFO_NULL,thefile,ierr)
+
+ !call mpi_file_set_view(thefile, disp, mpi_sd, &
+  !mpi_sd, 'native', &
+  !mpi_info_null, ierr)
+
+ call mpi_file_read_at(thefile,disp, buf, bufsize, mpi_sd, &
+                        mpi_status_ignore, ierr)
+
+ call mpi_file_close(thefile, ierr)
+
+ end subroutine mpi_read_col_dp
+!=======================================
+ subroutine mpi_read_dp(buf,bufsize,disp,nchar,fout)
+
+ real(dp),intent(inout) :: buf(:)
+ integer,intent(in) :: bufsize,nchar
+ integer(offset_kind),intent(in) :: disp
+ character(nchar),intent(in) :: fout
+
+ integer :: ierr,thefile
+
+ call mpi_file_open(comm, fout, &
+  mpi_mode_rdonly, &
+  mpi_INFO_NULL,thefile,ierr)
+ !call mpi_file_set_view(thefile, disp, mpi_sd, &
+ ! mpi_sd, 'native', mpi_info_null, ierr)
+                                           !call mpi_file_seek(thefile,disp,whence,ierr)
+ call mpi_file_read_at(thefile, disp,buf, bufsize, mpi_sd, &
+  mpi_status_ignore, ierr)
+
+ call mpi_file_close(thefile, ierr)
+
+ end subroutine mpi_read_dp
+!===============================
  subroutine mpi_write_part(buf,bufsize,loc_np,disp,nchar,fout)
 
  real(sp),intent(in) :: buf(:)
@@ -292,30 +399,6 @@
  call mpi_file_close(thefile, ierr)
 
  end subroutine mpi_write_part_col
- !========================
- subroutine mpi_write_dump_real(buf,bufsize,thefile)
-
- real(sp),intent(in) :: buf(:)
- integer,intent(in) :: bufsize, thefile
-
- integer :: ierr
-
- call mpi_file_write(thefile, buf, bufsize, mpi_real, &
-  mpi_status_ignore, ierr)
-
- end subroutine mpi_write_dump_real
- !========================
- subroutine mpi_write_dump_int(buf,bufsize,thefile)
-
- real(sp),intent(in) :: buf(:)
- integer,intent(in) :: bufsize, thefile
-
- integer :: ierr
-
- call mpi_file_write(thefile, buf, bufsize, mpi_integer, &
-  mpi_status_ignore, ierr)
-
- end subroutine mpi_write_dump_int
  !========================
  subroutine mpi_write_field(buf,bufsize,header,header_size,disp,nchar,fout)
 
@@ -905,7 +988,7 @@
  integer pes,per,tag
 
 
- tag=200+ip
+ tag=250+ip
  select case(dir)
  case(1)
   per=yp_prev(ip)
@@ -928,7 +1011,7 @@
  integer pes,per,tag
 
 
- tag=200
+ tag=610
  !================== side <0 receives from left   side >0 receives from right
  select case(dir)
  case(1)

--- a/src/particles.F90
+++ b/src/particles.F90
@@ -2997,13 +2997,13 @@
  ! enters av(1)=F=|a|^2/2 envelope at integer grid nodes
  ! and av(2:4)=grad[F] at staggered points
  !  COMPUTES
- !(E,B), F, gradF  assignements to particle positions 
- ! => ap(1:6)  in 2D 
+ !(E,B), F, gradF  assignements to particle positions
+ ! => ap(1:6)  in 2D
  ! => ap(1:10) in 3D
  ! approximated gamma function:
  ! gam_new= gam +0.25*charge*Dt(gam*E+0.5*grad[F]).p^{n-1/2}/gam^2
  ! EXIT
- ! (E+ 0.5grad[F]/gam_new) B/gam_new, F   and wgh/gam_new  
+ ! (E+ 0.5grad[F]/gam_new) B/gam_new, F   and wgh/gam_new
  ! pt(1:5)  in 2D
  ! pt(1:7)  in 3D
  !========================================
@@ -3106,7 +3106,7 @@
    gam_inv=(gam-dgam)/gam2
    ap(3:5)=ap(3:5)*gam_inv          !ap(3)=q*B/gamp, ap(4:5)= q*Grad[F]/2*gamp
 
-   pt(n,1:2)=ap(1:2)-ap(4:5)   ! Lorentz force already multiplied by q    
+   pt(n,1:2)=ap(1:2)-ap(4:5)   ! Lorentz force already multiplied by q
    pt(n,3)=ap(3)
    pt(n,5)=wgh*gam_inv     !weight/gamp
   end do

--- a/src/pic_dump.f90
+++ b/src/pic_dump.f90
@@ -35,7 +35,8 @@
  real(dp),intent(in) :: tloc
  character(13) :: fname='             '
  character(29) :: fname_out
- integer :: np,ic,lun,i,j,k
+ !integer :: lun
+ integer :: np,ic,i,j,k
  integer :: nxf_loc,nyf_loc,nzf_loc,nf
  integer :: i2b,j2b,k2b,nbf,env_cp,disp
  integer :: size_x,size_y,size_z,size_w
@@ -77,29 +78,30 @@
  ndata(8)=npt_buffer(1)
  ndata(9)=size(x)
  ndata(10)=nxf
- !if(pe0)write(6,*)'dump data',ndata(1:10)
+ if(pe0)write(6,*)'Start dump data'
  !==============
- lun=10
+ !lun=10
  fname_out='dumpRestart/'//fname//'.bin'
  !open (lun,file='dumpRestart/'//fname//'.bin',form='unformatted',status='unknown')
  disp=0
 
- call mpi_file_open(comm,fname_out, &
+ call mpi_file_open(single_communicator,fname_out, &
  mpi_mode_wronly + mpi_mode_create, &
  mpi_INFO_NULL,thefile,ierr)
- 
+
  call mpi_file_set_view(thefile, disp, mpi_real, &
  mpi_real, 'native', &
  mpi_info_null, ierr)
 
  buf_size=10
+ !call mpi_write_dump_real(rdata,buf_size,thefile)
  call mpi_file_write(thefile,rdata,buf_size, mpi_real, &
  mpi_status_ignore, ierr)
 
  buf_size=10
  call mpi_file_write(thefile,ndata,buf_size, mpi_integer, &
  mpi_status_ignore, ierr)
- 
+
  buf_size=nsp
  call mpi_file_write(thefile,nptx(1:nsp),buf_size, mpi_real, &
  mpi_status_ignore, ierr)
@@ -214,7 +216,7 @@
   !write(lun)up(:,:,:,:)
   !write(lun)up0(:,:,:,:)
  endif
-  
+
  ! if(Beam)then
   ! write(lun)ebf_bunch(1:i2b,1:j2b,1:k2b,1:nbf)
   ! if(ibeam==1)write(lun)ebf1_bunch(1:i2b,1:j2b,1:k2b,1:nbf)
@@ -265,6 +267,7 @@
  !close(lun)
  call mpi_file_close(thefile, ierr)
  unix_time_last_dump = unix_time_now
+ if(pe0)write(6,*)'End dump data'
  end subroutine dump_data
  !==============================================================
  !==============================================================

--- a/src/pic_dump.f90
+++ b/src/pic_dump.f90
@@ -28,37 +28,119 @@
  use parallel
 
  implicit none
- contains
 
+  real(dp),allocatable ::send_buff(:),recv_buff(:)
+ contains
+!----------------------
  subroutine dump_data(it_loc,tloc)
  integer,intent(in) :: it_loc
  real(dp),intent(in) :: tloc
- character(13) :: fname='             '
- character(29) :: fname_out
- !integer :: lun
- integer :: np,ic,i,j,k
- integer :: nxf_loc,nyf_loc,nzf_loc,nf
- integer :: i2b,j2b,k2b,nbf,env_cp,disp
- integer :: size_x,size_y,size_z,size_w
- real(dp) :: rdata(10), buf_size
+ character(9) :: fname='         '
+ character(9) :: fname_yz='         '
+ character(9) :: fname_ebf='         '
+ character(9) :: fname_env='         '
+ character(9) :: fname_fl='          '
+ character(9) :: fname_part='         '
+ character(11) :: fnamel_part='           '
+ character(11) :: fnamel_ebf ='           '
+ character(11) :: fnamel_env ='           '
+ character(11) :: fnamel_fl ='           '
+ character(11) :: foldername='           '
+ character(25) :: fname_out='                         '
+ character(27) :: fnamel_out='                           '
+ 
+ 
+ integer(offset_kind) :: disp,disp_col
+ integer :: max_npt_size
+ integer :: np,ic,ic1,lun,i,j,k,k1,k2,kk,ipe,lenbuff
+ integer :: nxf_loc,nyf_loc,nzf_loc,ndv
+ integer :: npt_arr(npe,nsp),ip_loc(npe)
+ integer :: loc_grid_size(npe),loc2d_grid_size(npe),lenw(npe)
+ integer :: grid_size_max,grid2d_size_max
+ integer :: env_cp,env1_cp,fl_cp,ebf_cp
+ real(dp) :: rdata(10)
  integer :: ndata(10),nps_loc(4),nbs_loc(5)
- integer :: ierr,thefile
+ integer :: dist_npy(npe_yloc,nsp),dist_npz(npe_zloc,nsp)
  !==============
- write (fname,'(a7,i6.6)') 'dumpout',mype
-
+ write (fname,'(a9)') 'Comm-data'
+ write (fname_yz,'(a9)') 'Dist-wgyz'
+ write (fname_ebf,'(a9)') 'EB-fields'
+ write (fname_env,'(a9)') 'ENVfields'
+ write (fname_fl,'(a9)') 'FL-fields'
+ write (fname_part,'(a9)') 'Particles'
+ write (foldername,'(a11)')'dumpRestart'
+!================field array sizes
  nxf_loc=size(ebf,1)
  nyf_loc=size(ebf,2)
  nzf_loc=size(ebf,3)
- nf=size(ebf,4)
- if(Beam)then
-  i2b=size(ebf_bunch,1)
-  j2b=size(ebf_bunch,2)
-  k2b=size(ebf_bunch,3)
-  nbf=size(ebf_bunch,4)
+ ebf_cp=size(ebf,4)
+
+ loc_grid_size(mype+1)=nxf_loc*nyf_loc*nzf_loc  !allowing for different grid sizes among mpi_tasks
+ loc2d_grid_size(mype+1)=nyf_loc*nzf_loc 
+ lenbuff=ebf_cp
+ if(Envelope)then
+  env1_cp=0
+  env_cp=size(env,4)
+  if(Two_color)env1_cp=env_cp
+  lenbuff=max(lenbuff,env_cp+env1_cp)
+ endif
+ grid2d_size_max=0
+ if(Hybrid)then
+  fl_cp=size(up,4)
+  lenbuff=max(lenbuff,2*fl_cp)
+  kk=loc2d_grid_size(mype+1)
+  call intvec_distribute(kk,loc2d_grid_size,npe)  
+  grid2d_size_max=maxval(loc2d_grid_size(1:npe))
+ endif
+!===============================
+ kk=loc_grid_size(mype+1)
+ grid_size_max=maxval(loc_grid_size(1:npe))
+ lenbuff=lenbuff*grid_size_max+grid2d_size_max
+!===============================
+ if(Part)then
+  ndv=size(ebfp,2)
+  do i=1,nsp
+   nps_loc(i)=size(spec(i)%part,1)
+   kk=loc_npart(imody,imodz,imodx,i)
+   call intvec_distribute(kk,ip_loc,npe)  
+   npt_arr(1:npe,i)=ip_loc(1:npe)
+  end do
+  do i=1,npe
+   ip_loc(i)=sum(npt_arr(i,1:nsp))
+  end do
+  max_npt_size=ndv*maxval(ip_loc(1:npe))
+  lenbuff=max(lenbuff,max_npt_size)
+!=============================
+  dist_npy(:,:)=0
+  dist_npz(:,:)=0
+  dist_npy(imody+1,1:nsp)=loc_npty(1:nsp)
+  dist_npz(imodz+1,1:nsp)=loc_nptz(1:nsp)
+  if(imody >0)then
+   call mpi_send(loc_npty,nsp,mpi_integer,pe0y,100+imody, &
+                    comm_col(1),error)
+  else
+   do ipe=1,npe_yloc-1
+    call mpi_recv(loc_npty,nsp,mpi_integer,ipe,100+ipe, &
+                    comm_col(1),status,error)
+    dist_npy(ipe+1,1:nsp)=loc_npty(1:nsp)
+   end do
+  endif
+  if(imodz >0)then
+   call mpi_send(loc_nptz,nsp,mpi_integer,pe0z,10+imodz, &
+                    comm_col(2),error)
+  else
+   do ipe=1,npe_zloc-1
+    call mpi_recv(loc_nptz,nsp,mpi_integer,ipe,10+ipe, &
+                    comm_col(2),status,error)
+    dist_npz(ipe+1,1:nsp)=loc_nptz(1:nsp)
+   end do
+  endif
+!===================
  endif
  !=========================
  ndata=0
  rdata=0.0
+!====================
  rdata(1)=tloc
  rdata(2)=j0_norm
  rdata(3)=ompe
@@ -67,365 +149,590 @@
  rdata(6)=lp_in(1)
  rdata(7)=xp0_out
  rdata(8)=xp1_out
+ rdata(9)=x(1)
 
  ndata(1)=it_loc
  ndata(2)=nxf_loc
  ndata(3)=nyf_loc
  ndata(4)=nzf_loc
- ndata(5)=nf
- ndata(6)=nptx_max
- ndata(7)=npty
- ndata(8)=npt_buffer(1)
- ndata(9)=size(x)
- ndata(10)=nxf
- if(pe0)write(6,*)'Start dump data'
+ ndata(5)=nptx_max
+ ndata(6)=size(x)
+ ndata(7)=nxf
+ ndata(8)=nd2
+!==========================
  !==============
- !lun=10
- fname_out='dumpRestart/'//fname//'.bin'
- !open (lun,file='dumpRestart/'//fname//'.bin',form='unformatted',status='unknown')
- disp=0
-
- call mpi_file_open(single_communicator,fname_out, &
- mpi_mode_wronly + mpi_mode_create, &
- mpi_INFO_NULL,thefile,ierr)
-
- call mpi_file_set_view(thefile, disp, mpi_real, &
- mpi_real, 'native', &
- mpi_info_null, ierr)
-
- buf_size=10
- !call mpi_write_dump_real(rdata,buf_size,thefile)
- call mpi_file_write(thefile,rdata,buf_size, mpi_real, &
- mpi_status_ignore, ierr)
-
- buf_size=10
- call mpi_file_write(thefile,ndata,buf_size, mpi_integer, &
- mpi_status_ignore, ierr)
-
- buf_size=nsp
- call mpi_file_write(thefile,nptx(1:nsp),buf_size, mpi_real, &
- mpi_status_ignore, ierr)
-
- buf_size=nsp
- call mpi_file_write(thefile,sptx_max(1:nsp),buf_size, mpi_real, &
- mpi_status_ignore, ierr)
-
- i=ndata(9)
- buf_size=i
- call mpi_file_write(thefile,x(1:i),buf_size, mpi_real, &
- mpi_status_ignore, ierr)
-
- !write(lun)rdata(1:10)
- !write(lun)ndata(1:10)
- !write(lun)nptx(1:nsp)
- !write(lun)sptx_max(1:nsp)
- !i=ndata(9)
- !write(lun)x(1:i)
- !-----------------------------
- if(Hybrid)then
-  if(nxf >0)then
-   buf_size=nxf
-   call mpi_file_write(thefile,fluid_x_profile(1:nxf),buf_size, mpi_real, &
-   mpi_status_ignore, ierr)
-   buf_size=nyf_loc*nzf_loc
-   call mpi_file_write(thefile,fluid_yz_profile(1:nyf_loc,1:nzf_loc), &
-   buf_size, mpi_real, &
-   mpi_status_ignore, ierr)
-   !write(lun)fluid_x_profile(1:nxf)
-   !write(lun)fluid_yz_profile(1:nyf_loc,1:nzf_loc)
-  endif
- endif
-
- if(targ_end > xmax)then
-  buf_size=1
-  do i=1,nsp
-   call mpi_file_write(thefile,loc_npty(i), &
-   buf_size, mpi_real, &
-   mpi_status_ignore, ierr)
-   call mpi_file_write(thefile,loc_nptz(i), &
-   buf_size, mpi_real, &
-   mpi_status_ignore, ierr)
-   !write(lun)loc_npty(i),loc_nptz(i)
-  end do
-  do i=1,nsp
-   do j=1,nptx_max
-    call mpi_file_write(thefile,xpt(j,i), &
-    buf_size, mpi_real, &
-    mpi_status_ignore, ierr)
-    call mpi_file_write(thefile,wghpt(j,i), &
-    buf_size, mpi_real, &
-    mpi_status_ignore, ierr)
-    !write(lun)xpt(j,i),wghpt(j,i)
-   end do
-   do j=1,loc_npty(i)
-    call mpi_file_write(thefile,loc_ypt(j,i), &
-    buf_size, mpi_real, &
-    mpi_status_ignore, ierr)
-    !write(lun)loc_ypt(j,i)
-   end do
-   do k=1,loc_nptz(i)
-    call mpi_file_write(thefile,loc_zpt(k,i), &
-    buf_size, mpi_real, &
-    mpi_status_ignore, ierr)
-    !write(lun)loc_zpt(k,i)
-    do j=1,loc_npty(i)
-     call mpi_file_write(thefile,loc_wghyz(j,k,i), &
-     buf_size, mpi_real, &
-     mpi_status_ignore, ierr)
-     !write(lun)loc_wghyz(j,k,i)
+ lun=10
+ if(pe0)then
+open (lun,file='dumpRestart/'//fname//'.bin',form='unformatted',status='unknown')
+  write(lun)rdata(1:10)
+  write(lun)ndata(1:10)
+  write(lun)nptx(1:nsp)
+  write(lun)sptx_max(1:nsp)
+!=====================
+  if(targ_end > xmax)then
+   do i=1,nsp
+    do j=1,nptx_max
+     write(lun)xpt(j,i),wghpt(j,i)
     end do
    end do
-  end do
- endif
- !-----------------------
- !========================
- buf_size=nxf_loc*nyf_loc*nzf_loc*nf
- call mpi_file_write(thefile,ebf(:,:,:,:), &
- buf_size, mpi_real, &
- mpi_status_ignore, ierr)
- !write(lun)ebf(:,:,:,:)
- if(Envelope)then
-  env_cp=size(env,4)
-  size_x=size(env,1)
-  size_y=size(env,2)
-  size_z=size(env,3)
-  buf_size=size_x*size_y*size_z*env_cp
-  call mpi_file_write(thefile,env(:,:,:,:), &
-  buf_size, mpi_real, &
-  mpi_status_ignore, ierr)
-  !write(lun)env(:,:,:,:)
-  if(Two_color)then
-   call mpi_file_write(thefile,env1(:,:,:,:), &
-   buf_size, mpi_real, &
-   mpi_status_ignore, ierr)
-   !write(lun)env1(:,:,:,:)
+   if(Hybrid)then
+    if(nxf >0)then
+     write(lun)fluid_x_profile(1:nxf)
+    endif
+   endif
   endif
- endif
- if(Hybrid)then
-  size_w=size(up,4)
-  size_x=size(up,1)
-  size_y=size(up,2)
-  size_z=size(up,3)
-  buf_size=size_x*size_y*size_z*env_cp
-  call mpi_file_write(thefile,up(:,:,:,:), &
-  buf_size, mpi_real, &
-  mpi_status_ignore, ierr)
-  call mpi_file_write(thefile,up0(:,:,:,:), &
-  buf_size, mpi_real, &
-  mpi_status_ignore, ierr)
-  !write(lun)up(:,:,:,:)
-  !write(lun)up0(:,:,:,:)
- endif
-
- ! if(Beam)then
-  ! write(lun)ebf_bunch(1:i2b,1:j2b,1:k2b,1:nbf)
-  ! if(ibeam==1)write(lun)ebf1_bunch(1:i2b,1:j2b,1:k2b,1:nbf)
-  ! if(Pbeam)write(lun)ebf0_bunch(1:i2b,1:j2b,1:k2b,1:3)
-  ! if(L_Bpoloidal)write(lun)ebf0_bunch(1:i2b,1:j2b,1:k2b,1:3)
- ! endif
- !========================================Particle section
+  if(Part)then
+   write(lun)npt_arr(1:npe,1:nsp)
+   write(lun)dist_npy(1:npe_yloc,1:nsp)
+   write(lun)dist_npz(1:npe_zloc,1:nsp)
+  endif
+!==================
+  close(lun)
+ endif       !end pe0 write on fname
+ if(pe0)write(6,*)'end write comm'
+!===========================
+ allocate(send_buff(lenbuff))     !to be used for all mpi_write()
+!=====================
  if(Part)then
-  do i=1,nsp
-   nps_loc(i)=size(spec(i)%part,1)
-  end do
-  buf_size=nsp
-  call mpi_file_write(thefile,nps_loc(1:nsp), &
-  buf_size, mpi_real, &
-  mpi_status_ignore, ierr)
-  !write(lun)nps_loc(1:nsp)
-  buf_size=npe_yloc*npe_zloc*npe_yloc*nsp
-  call mpi_file_write(thefile,loc_npart(0:npe_yloc-1,0:npe_zloc-1,0:npe_xloc-1,1:nsp), &
-  buf_size, mpi_real, &
-  mpi_status_ignore, ierr)
-  !write(lun)loc_npart(0:npe_yloc-1,0:npe_zloc-1,0:npe_xloc-1,1:nsp)
+  write (fnamel_part,'(a9,i2.2)') 'Particles',imodz
+  fnamel_out='dumpRestart/'//fnamel_part//'.bin'
+  lenw(1:npe)=ndv*ip_loc(1:npe)
+  max_npt_size=maxval(lenw(1:npe))
+  kk=0
   do ic=1,nsp
    np=loc_npart(imody,imodz,imodx,ic)
    if(np >0)then
-    buf_size=np*(nd2+1)
-    ebfp(1:np,1:nd2+1)=spec(ic)%part(1:np,1:nd2+1)
-    call mpi_file_write(thefile,ebfp(1:np,1:nd2+1), &
-    buf_size, mpi_real, &
-    mpi_status_ignore, ierr)
-    !write(lun)ebfp(1:np,1:nd2+1)
+    do j=1,ndv
+     do i=1,np
+      kk=kk+1
+      send_buff(kk)=spec(ic)%part(i,j)
+     end do
+    end do
    endif
   end do
+  disp_col=0
+  if(MOD(mype,npe_yloc) > 0)disp_col=sum(lenw(imodz*npe_yloc+1:mype)) 
+  disp_col=8*disp_col
+  call mpi_write_col_dp(send_buff,lenw(mype+1),disp_col,27,fnamel_out)
  endif
- ! if(Beam)then
-  ! do i=1,nsb
-   ! nbs_loc(i)=size(bunch(i)%part,1)
-  ! end do
-  ! write(lun)nbs_loc(1:nsb)
-  ! write(lun)loc_nbpart(0:npe_yloc-1,0:npe_zloc-1,0:npe_xloc-1,1:nsb)
-  ! do ic=1,nsb
-   ! np=loc_nbpart(imody,imodz,imodx,ic)
-   ! if(np >0)then
-    ! ebfb(1:np,1:nd2+1)=bunch(ic)%part(1:np,1:nd2+1)
-    ! write(lun)ebfb(1:np,1:nd2+1)
-   ! endif
-  ! end do
- ! endif
- !close(lun)
- call mpi_file_close(thefile, ierr)
- unix_time_last_dump = unix_time_now
- if(pe0)write(6,*)'End dump data'
+!===============================
+ write (fnamel_ebf,'(a9,i2.2)') 'EB-fields',imodz
+ fnamel_out='dumpRestart/'//fnamel_ebf//'.bin'
+ lenw(1:npe)=ebf_cp*loc_grid_size(1:npe)
+ kk=0
+ do ic=1,ebf_cp
+  do k=1,nzf_loc
+   do j=1,nyf_loc
+    do i=1,nxf_loc
+     kk=kk+1
+     send_buff(kk)=ebf(i,j,k,ic)
+    end do
+   end do
+  end do
+ end do
+
+ disp_col=8*imody*lenw(1+mype)
+ call mpi_write_col_dp(send_buff,lenw(1+mype),disp_col,27,fnamel_out)
+ if(pe0)write(6,*)'end write field'
+ !========================
+ if(envelope)then
+  write (fnamel_env,'(a9,i2.2)') 'ENVfields',imodz
+  fnamel_out='dumpRestart/'//fnamel_env//'.bin'
+  lenw(1:npe)=(env_cp+env1_cp)*loc_grid_size(1:npe)
+  kk=0
+  do ic=1,env_cp
+   do k=1,nzf_loc
+    do j=1,nyf_loc
+     do i=1,nxf_loc
+      kk=kk+1
+      send_buff(kk)=env(i,j,k,ic)
+     end do
+    end do
+   end do
+  end do
+  if(Two_color)then
+   do ic=1,env1_cp
+    do k=1,nzf_loc
+     do j=1,nyf_loc
+      do i=1,nxf_loc
+       kk=kk+1
+       send_buff(kk)=env1(i,j,k,ic)
+      end do
+     end do
+    end do
+   end do
+  endif
+  disp_col=8*imody*lenw(1+mype)
+  call mpi_write_col_dp(send_buff,lenw(mype+1),disp_col,27,fnamel_out)
+ if(pe0)write(6,*)'end write env'
+ endif
+ if(Hybrid)then
+  write (fnamel_fl,'(a9,i2.2)')'FL-fields',imodz
+  fnamel_out='dumpRestart/'//fnamel_fl//'.bin'
+  lenw(1:npe)=2*fl_cp*loc_grid_size(1:npe)+loc2d_grid_size(1:npe)
+  kk=0
+  do k=1,nzf_loc
+   do j=1,nyf_loc
+    kk=kk+1
+    send_buff(kk)=fluid_yz_profile(j,k)
+   end do
+  end do
+  do ic=1,fl_cp
+   do k=1,nzf_loc
+    do j=1,nyf_loc
+     do i=1,nxf_loc
+      kk=kk+1
+      send_buff(kk)=up(i,j,k,ic)
+     end do
+    end do
+   end do
+  end do
+  do ic=1,fl_cp
+   do k=1,nzf_loc
+    do j=1,nyf_loc
+     do i=1,nxf_loc
+      kk=kk+1
+      send_buff(kk)=up0(i,j,k,ic)
+     end do
+    end do
+   end do
+  end do
+  disp_col=8*imody*lenw(1+mype)
+  call mpi_write_col_dp(send_buff,lenw(1+mype),disp_col,27,fnamel_out)
+ if(pe0)write(6,*)'end write fluid'
+ endif
+!============== write (y,z,wghyz initial part distribution
+ if(Part)then
+  fname_out='dumpRestart/'//fname_yz//'.bin'
+   kk=0
+   do ic=1,nsp
+    if(loc_npty(ic)>0)then
+     do i=1,loc_npty(ic)
+      kk=kk+1
+      send_buff(kk)=loc_ypt(i,ic)
+     end do
+    endif
+   enddo
+   do ic=1,nsp
+    if(loc_nptz(ic)>0)then
+     do j=1,loc_nptz(ic)
+      kk=kk+1
+      send_buff(kk)=loc_zpt(j,ic)
+     end do
+    endif
+   end do
+!================================
+   do ic=1,nsp
+    if(loc_nptz(ic)>0)then
+     do j=1,loc_nptz(ic)
+      if(loc_npty(ic)>0)then
+       do i=1,loc_npty(ic)
+        kk=kk+1
+        send_buff(kk)=loc_wghyz(i,j,ic)
+       end do
+      endif
+     end do
+    endif
+   end do
+  call intvec_distribute(kk,lenw,npe)  
+  disp=0
+  if(mype >0)disp=8*sum(lenw(1:mype))
+  call mpi_write_dp(send_buff,lenw(mype+1),disp,25,fname_out)
+ endif
+  deallocate(send_buff)
+!====================
+ !----------------------- FIELD DUMP
+  unix_time_last_dump = unix_time_now
+  if(pe0)write(6,*)'END TOTAL DUMP WRITE'
  end subroutine dump_data
  !==============================================================
  !==============================================================
  subroutine restart(it_loc,tloc)
  integer,intent(out) :: it_loc
  real(dp),intent(out) :: tloc
- character(13) :: fname='             '
- integer :: np,nps_loc(4),nbs_loc(5),np_max
- integer :: n1_old,lun,i,j,k,ic
- integer :: nxf_loc,nyf_loc,nzf_loc,nf,npt_max
- integer :: i2b,j2b,k2b,nbf,env_cp
- integer :: n1_loc,n2_loc,n3_loc,nf_loc,loc_npty_max,loc_nptz_max
- real(dp) :: rdata(10)
- integer :: ndata(10)
- real(dp),allocatable :: xx(:)
-
+ character(9) :: fname='         '
+ character(9) :: fname_yz='         '
+ character(9) :: fname_ebf='         '
+ character(9) :: fname_env='         '
+ character(9) :: fname_fl='          '
+ character(9) :: fname_part='         '
+ character(11) :: fnamel_part='           '
+ character(11) :: fnamel_ebf ='           '
+ character(11) :: fnamel_env ='           '
+ character(11) :: fnamel_fl ='           '
+ character(11) :: foldername='           '
+ character(25) :: fname_out='                         '
+ character(27) :: fnamel_out='                           '
+ integer(offset_kind) :: disp,disp_col
+ integer :: max_npt_size,npy_max,npz_max,ipe,npt_arr(npe,nsp)
+ integer :: np,ic,ic1,lun,i,j,k,kk,k1,k2,jj,lenw(npe),lenbuff
+ integer :: nxf_loc,nyf_loc,nzf_loc,ndv
+ integer :: ip_loc(npe),loc_grid_size(npe),loc2d_grid_size(npe)
+ integer :: grid_size_max,grid2d_size_max
+ integer :: env_cp,env1_cp,fl_cp,ebf_cp,nypt(10),nzpt(10)
+ integer :: ndata(10),nps_loc(4),np_max,n1_old
+ integer :: n1_loc,n2_loc,n3_loc,nypt_max,nzpt_max
+ integer :: dist_npy(npe_yloc,nsp),dist_npz(npe_zloc,nsp)
+ real(dp) :: rdata(10),x0_new
+ 
  !==============
- write (fname,'(a7,i6.6)') 'dumpout',mype
- !==============
+ write (fname,'(a9)') 'Comm-data'
+ write (fname_ebf,'(a9)') 'EB-fields'
+ write (fname_env,'(a9)') 'ENVfields'
+ write (fname_fl,'(a9)') 'FL-fields'
+ write (fname_part,'(a9)') 'Particles'
+ write (foldername,'(a11)')'dumpRestart'
+ write (fname_yz,'(a9)') 'Dist-wgyz'
+ !==============       Already defined data
+ n1_loc=size(ebf,1)
+ n2_loc=size(ebf,2)
+ n3_loc=size(ebf,3)
+ ebf_cp=size(ebf,4)
+!===================
+ loc_grid_size(mype+1)=n1_loc*n2_loc*n3_loc
+ loc2d_grid_size(mype+1)=n2_loc*n3_loc
+ lenbuff=ebf_cp
+ if(Envelope)then
+  env1=0
+  env_cp=size(env,4)
+  if(Two_color)env1_cp=env_cp
+  lenbuff=max(lenbuff,env_cp+env1_cp)
+ endif
+ grid2d_size_max=0
+ if(Hybrid)then
+  fl_cp=size(up,4)
+  lenbuff=max(lenbuff,2*fl_cp)
+  kk=loc2d_grid_size(mype+1)
+  call intvec_distribute(kk,loc2d_grid_size,npe)  
+  grid2d_size_max=maxval(loc2d_grid_size(1:npe))
+ endif
+ kk=loc_grid_size(mype+1)
+ call intvec_distribute(kk,loc_grid_size,npe)  
+ grid_size_max=maxval(loc_grid_size(1:npe))
+ lenbuff=lenbuff*grid_size_max+grid2d_size_max
+!===================
  lun=10
+ if(pe0)then
  open (lun,file='dumpRestart/'//fname//'.bin',form='unformatted',status='unknown')
-
- read(lun)rdata(1:10)
- read(lun)ndata(1:10)
- read(lun)nptx(1:nsp)
- read(lun)sptx_max(1:nsp)
+  read(lun)rdata(1:10)
+  read(lun)ndata(1:10)
+  read(lun)nptx(1:nsp)
+  read(lun)sptx_max(1:nsp)
+  it_loc=ndata(1)
+  nptx_max=ndata(5)
+  n1_old=ndata(6)
+  nxf=ndata(7)
+  ndv=ndata(8)+1
+!=========================
+  tloc=rdata(1)
+  targ_in=rdata(4)
+  targ_end=rdata(5)
+  lp_in(1)=rdata(6)
+  x0_new= rdata(9)
  !=============================
+  if(targ_end > xmax+x0_new)then
+   allocate(xpt(nptx_max,nsp))
+   allocate(wghpt(nptx_max,nsp))
+   do i=1,nsp
+    do j=1,nptx_max
+     read(lun)xpt(j,i),wghpt(j,i)
+    end do
+   end do
+   if(Hybrid)then
+    if(nxf>0)then
+     allocate(fluid_x_profile(nxf))
+     read(lun)fluid_x_profile(1:nxf)
+    endif
+   endif
+  endif
+  if(Part)then
+   read(lun)npt_arr(1:npe,1:nsp)
+   read(lun)dist_npy(1:npe_yloc,1:nsp)
+   read(lun)dist_npz(1:npe_zloc,1:nsp)
+  endif
+  close(lun)
+ endif               !end pe0 read on fname
+!========================= distribute comm data
+ kk=size(rdata)
+ k1=size(ndata)
+ call mpi_bcast(ndata,k1,mpi_integer,pe_min,comm,error)
+ call mpi_bcast(nptx,nsp,mpi_integer,pe_min,comm,error)
+ call mpi_bcast(sptx_max,nsp,mpi_integer,pe_min,comm,error)
+ call mpi_bcast(rdata,kk,mpi_sd,pe_min,comm,error)
+
+ it_loc=ndata(1)
+ nptx_max=ndata(5)
+ n1_old=ndata(6)
+ nxf=ndata(7)
+ ndv=ndata(8)+1
+!=========================
  tloc=rdata(1)
- j0_norm=rdata(2)
- ompe=rdata(3)
  targ_in=rdata(4)
  targ_end=rdata(5)
  lp_in(1)=rdata(6)
-
- it_loc=ndata(1)
- n1_loc=ndata(2)
- n2_loc=ndata(3)
- n3_loc=ndata(4)
- nf_loc=ndata(5)
- nptx_max=ndata(6)
- npty=ndata(7)
- nptz=npty
- npt_max=ndata(8)
- n1_old=ndata(9)
- nxf=ndata(10)
- !=======================================
- !=======================================
- allocate(xx(n1_old))
- i=ndata(9)
- read(lun)xx(1:i)
- if(Hybrid)then
-  if(nxf>0)then
-   allocate(fluid_x_profile(nxf))
-   allocate(fluid_yz_profile(1:n2_loc,1:n3_loc))
-   read(lun)fluid_x_profile(1:nxf)
-   read(lun)fluid_yz_profile(1:n2_loc,1:n3_loc)
+ x0_new= rdata(9)
+ if(x0_new>0.0)then
+  x=x+x0_new
+  xh=xh+x0_new
+  xmin=xmin+x0_new
+  xmax=xmax+x0_new
+  loc_xgrid(imodx)%gmin=loc_xgrid(imodx)%gmin+x0_new
+  loc_xgrid(imodx)%gmax=loc_xgrid(imodx)%gmax+x0_new
+  xp0_out=xp0_out+x0_new
+  xp1_out=xp1_out+x0_new
+ endif
+ if(targ_end > xmax)then
+  if(mype >0)then
+   allocate(xpt(nptx_max,nsp))
+   allocate(wghpt(nptx_max,nsp))
+   if(Hybrid)then
+    if(nxf >0)allocate(fluid_x_profile(nxf))
+   endif
+  endif
+  if(pe0)then
+   do ipe=1,npe-1
+    call mpi_send(xpt(1,1),nptx_max*nsp,mpi_double_precision,ipe,100+ipe, &
+                    comm,error)
+    call mpi_send(wghpt(1,1),nptx_max*nsp,mpi_double_precision,ipe,400+ipe, &
+                    comm,error)
+   enddo
+  else
+   call mpi_recv(xpt(1,1),nptx_max*nsp,mpi_double_precision,pe_min,100+mype, &
+      comm,status,error)
+   call mpi_recv(wghpt(1,1),nptx_max*nsp,mpi_double_precision,pe_min,400+mype, &
+      comm,status,error)
+  endif
+!===========================
+  if(Hybrid)then
+   if(nxf>0)then
+    if(pe0)then
+     do ipe=1,npe-1
+      call mpi_send(fluid_x_profile(1),nxf,mpi_double_precision,ipe,10+ipe, &
+                    comm,error)
+     enddo
+    else
+     call mpi_recv(fluid_x_profile(1),nxf,mpi_double_precision,pe_min,10+mype, &
+      comm,status,error)
+    endif
+   endif
   endif
  endif
- !===================
+ if(Part)then
+                 !distributes npart => npt(npe,nsp)
+  call mpi_bcast(npt_arr(1,1),npe*nsp,mpi_integer,pe_min,comm,error)
+  do i=1,npe
+   ip_loc(i)=sum(npt_arr(i,1:nsp))
+  enddo
+  max_npt_size=ndv*maxval(ip_loc(1:npe))
+  lenbuff=max(lenbuff,max_npt_size)
+  ipe=0
+   do i=0,npe_xloc-1
+    do j=0,npe_zloc-1
+     do k=0,npe_yloc-1
+      loc_npart(k,j,i,1:nsp)=npt_arr(ipe+1,1:nsp)
+      ipe=ipe+1
+     end do
+    end do
+   end do
+!========== distributes npty,nptz initial particle distribution
+  call mpi_bcast(dist_npy(1,1),npe_yloc*nsp,mpi_integer,pe_min,comm,error)
+  call mpi_bcast(dist_npz(1,1),npe_zloc*nsp,mpi_integer,pe_min,comm,error)
+  loc_npty(1:nsp)=dist_npy(imody+1,1:nsp)
+  loc_nptz(1:nsp)=dist_npz(imodz+1,1:nsp)
+  nypt_max=maxval(loc_npty(1:nsp))
+  nzpt_max=maxval(loc_nptz(1:nsp))
+  allocate(loc_ypt(nypt_max,nsp))
+  allocate(loc_zpt(nzpt_max,nsp))
+  allocate(loc_wghyz(nypt_max,nzpt_max,nsp))
+ endif    !end n_part distribut
  ! x() defined on the grid module starting from x(1)=0.0
- if(xx(1) >0.0)then
-  x=x+xx(1)
-  xh=xh+xx(1)
-  xmin=xmin+xx(1)
-  xmax=xmax+xx(1)
-  loc_xgrid(imodx)%gmin=loc_xgrid(imodx)%gmin+xx(1)
-  loc_xgrid(imodx)%gmax=loc_xgrid(imodx)%gmax+xx(1)
-  xp0_out=xp0_out+xx(1)
-  xp1_out=xp1_out+xx(1)
- endif
- !===================
- if(targ_end > xmax)then
+!---------- Particle read
+!============================================
+ allocate(recv_buff(lenbuff))
+ recv_buff(:)=0.0
+!============================================
+ if(Part)then
+  write (fnamel_part,'(a9,i2.2)') 'Particles',imodz
+  fnamel_out='dumpRestart/'//fnamel_part//'.bin'
+
   do i=1,nsp
-   read(lun)loc_npty(i),loc_nptz(i)
+   nps_loc(i)=maxval(npt_arr(1:npe,i))
   end do
-  loc_npty_max=maxval(loc_npty(1:nsp))
-  loc_nptz_max=maxval(loc_nptz(1:nsp))
-  allocate(xpt(nptx_max,nsp))
-  allocate(wghpt(nptx_max,nsp))
-  allocate(loc_ypt(loc_npty_max,nsp))
-  allocate(loc_zpt(loc_nptz_max,nsp))
-  allocate(loc_wghyz(loc_npty_max,loc_nptz_max,nsp))
-  do i=1,nsp
-   do j=1,nptx_max
-    read(lun)xpt(j,i),wghpt(j,i)
+  np_max=maxval(nps_loc(1:nsp))
+  call p_alloc(np_max,ndv,nps_loc,nsp,LPf_ord,1,1,mem_psize)
+  lenw(1:npe)=ndv*ip_loc(1:npe)
+!=======================
+  disp_col=0
+  if(MOD(mype,npe_yloc) > 0)disp_col=sum(lenw(imodz*npe_yloc+1:mype)) 
+  disp_col=8*disp_col
+  call mpi_read_col_dp(recv_buff,lenw(1+mype),disp_col,27,fnamel_out)
+!==============================
+  kk=0
+  do ic=1,nsp
+   np=loc_npart(imody,imodz,imodx,ic)
+   if(np >0)then
+    do j=1,ndv
+     do i=1,np
+      kk=kk+1
+      spec(ic)%part(i,j)=recv_buff(kk)
+     end do
+    end do
+   endif
+  end do
+ endif
+!=================================
+ !--------------------- FIELD DUMP READ
+ write (fnamel_ebf,'(a9,i2.2)') 'EB-fields',imodz
+ fnamel_out='dumpRestart/'//fnamel_ebf//'.bin'
+ lenw(1:npe)=ebf_cp*loc_grid_size(1:npe)
+!=========================
+ disp_col=8*imody*lenw(1+mype)
+ call mpi_read_col_dp(recv_buff,lenw(1+mype),disp_col,27,fnamel_out)
+!===========================
+  kk=0
+   do ic=1,ebf_cp
+    do k=1,n3_loc
+     do j=1,n2_loc
+      do i=1,n1_loc
+       kk=kk+1
+       ebf(i,j,k,ic)=recv_buff(kk)
+      end do
+     end do
+    end do
    end do
-   do j=1,loc_npty(i)
-    read(lun)loc_ypt(j,i)
+ !========================
+ if(Hybrid)then
+  write (fnamel_fl,'(a9,i2.2)') 'FL-fields',imodz
+  fnamel_out='dumpRestart/'//fnamel_fl//'.bin'
+  lenw(1:npe)=2*fl_cp*loc_grid_size(1:npe)+loc2d_grid_size(1:npe)
+!==========================
+  disp_col=8*imody*lenw(1+mype)
+  call mpi_read_col_dp(recv_buff,lenw(1+mype),disp_col,27,fnamel_out)
+!================================
+  kk=0
+  do k=1,n3_loc
+   do j=1,n2_loc
+    kk=kk+1
+    fluid_yz_profile(j,k)=recv_buff(kk)
    end do
-   do k=1,loc_nptz(i)
-    read(lun)loc_zpt(k,i)
-    do j=1,loc_npty(i)
-     read(lun)loc_wghyz(j,k,i)
+  end do
+  do ic=1,fl_cp
+   do k=1,n3_loc
+    do j=1,n2_loc
+     do i=1,n1_loc
+      kk=kk+1
+      up(i,j,k,ic)=recv_buff(kk)
+     end do
+    end do
+   end do
+  end do
+  do ic=1,fl_cp
+   do k=1,n3_loc
+    do j=1,n2_loc
+     do i=1,n1_loc
+      kk=kk+1
+      up0(i,j,k,ic)=recv_buff(kk)
+     end do
     end do
    end do
   end do
  endif
- !=========================
- !=============== field dimensions
- nxf_loc=size(ebf,1)
- nyf_loc=size(ebf,2)
- nzf_loc=size(ebf,3)
- nf=size(ebf,4)
- if(Beam)then
-  i2b=size(ebf_bunch,1)
-  j2b=size(ebf_bunch,2)
-  k2b=size(ebf_bunch,3)
-  nbf=size(ebf_bunch,4)
- endif
- !=================
- read(lun)ebf(:,:,:,:)
- if(Envelope)then
-  env_cp=size(env,4)
-  read(lun)env(:,:,:,:)
-  if(Two_color)read(lun)env1(:,:,:,:)
- endif
- if(Hybrid)then
-  read(lun)up(:,:,:,:)
-  read(lun)up0(:,:,:,:)
- endif
- if(Beam)then
-  read(lun)ebf_bunch(1:i2b,1:j2b,1:k2b,1:nbf)
-  if(ibeam==1)read(lun)ebf1_bunch(1:i2b,1:j2b,1:k2b,1:nbf)
-  if(Pbeam)read(lun)ebf0_bunch(1:i2b,1:j2b,1:k2b,1:3)
-  if(L_Bpoloidal)read(lun)ebf0_bunch(1:i2b,1:j2b,1:k2b,1:3)
- endif
- !=========== end field section
- if(Part)then
-  read(lun)nps_loc(1:nsp)
-  read(lun)loc_npart(0:npe_yloc-1,0:npe_zloc-1,0:npe_xloc-1,1:nsp)
-  np_max=nps_loc(1)
-  call p_alloc(np_max,nd2+1,nps_loc,nsp,LPf_ord,1,1,mem_psize)
-  !=========================
-  do ic=1,nsp
-   np=loc_npart(imody,imodz,imodx,ic)
-   if(np >0)then
-    read(lun)ebfp(1:np,1:nd2+1)
-    spec(ic)%part(1:np,1:nd2+1)=ebfp(1:np,1:nd2+1)
-   endif
+!================
+ if(envelope)then
+  write (fnamel_env,'(a9,i2.2)') 'ENVfields',imodz
+  fnamel_out='dumpRestart/'//fnamel_env//'.bin'
+  lenw(1:npe)=(env_cp+env1_cp)*loc_grid_size(1:npe)
+!==================
+  disp_col=8*imody*lenw(1+mype)
+  call mpi_read_col_dp(recv_buff,lenw(1+mype),disp_col,27,fnamel_out)
+!======================
+  kk=0
+  do ic=1,env_cp
+   do k=1,n3_loc
+    do j=1,n2_loc
+     do i=1,n1_loc
+      kk=kk+1
+      env(i,j,k,ic)=recv_buff(kk)
+     end do
+    end do
+   end do
   end do
-  if(Beam)then
-   read(lun)nbs_loc(1:nsb)
-   read(lun)loc_nbpart(0:npe_yloc-1,0:npe_zloc-1,0:npe_xloc-1,1:nsb)
-   np_max=maxval(nbs_loc(1:nsb))
-   if(np_max >0)call p_alloc(np_max,nd2+1,nbs_loc,nsb,LPf_ord,1,2,mem_psize)
-   !========================
-   do ic=1,nsb
-    np=loc_nbpart(imody,imodz,imodx,ic)
-    if(np >0)then
-     read(lun)ebfb(1:np,1:nd2+1)
-     bunch(ic)%part(1:np,1:nd2+1)=ebfb(1:np,1:nd2+1)
-    endif
+  if(Two_color)then
+   do ic=1,env1_cp
+    do k=1,n3_loc
+     do j=1,n2_loc
+      do i=1,n1_loc
+       kk=kk+1
+       env1(i,j,k,ic)=recv_buff(kk)
+      end do
+     end do
+    end do
    end do
   endif
  endif
- !====================
- close(lun)
- !====================
+!=========================
+ if(Part)then
+  fname_out='dumpRestart/'//fname_yz//'.bin'
+   kk=0
+   do ic=1,nsp
+    if(loc_npty(ic) >0)then
+     do i=1,loc_npty(ic)
+      kk=kk+1
+     end do
+    endif
+   end do
+   do ic=1,nsp
+    if(loc_nptz(ic) >0)then
+     do j=1,loc_nptz(ic)
+      kk=kk+1
+     end do
+    endif
+   end do
+   do ic=1,nsp
+    if(loc_nptz(ic) >0)then
+     do j=1,loc_nptz(ic)
+      if(loc_npty(ic) >0)then
+       do i=1,loc_npty(ic)
+        kk=kk+1
+       end do
+      endif
+     end do
+    endif
+   end do
+  
+  call intvec_distribute(kk,lenw,npe)  
+  disp=0
+  if(mype >0)disp=sum(lenw(1:mype))
+  disp=8*disp
+  call mpi_read_dp(recv_buff,lenw(mype+1),disp,25,fname_out)
+
+   kk=0
+   do ic=1,nsp
+    do i=1,loc_npty(ic)
+     kk=kk+1
+     loc_ypt(i,ic)=recv_buff(kk)
+    end do
+   enddo
+   do ic=1,nsp
+    do j=1,loc_nptz(ic)
+     kk=kk+1
+     loc_zpt(j,ic)=recv_buff(kk)
+    end do
+   end do
+   do ic=1,nsp
+    do j=1,loc_nptz(ic)
+     do i=1,loc_npty(ic)
+      kk=kk+1
+      loc_wghyz(i,j,ic)=recv_buff(kk)
+     end do
+    end do
+   end do
+  endif                   !end of part read
+!============================================
+  deallocate(recv_buff)
+!===================================
+!===============================
+ if(pe0)write(6,*)'END TOTAL DUMP READ'
  end subroutine restart
  !===========================
  end module pic_dump

--- a/src/pic_dump.f90
+++ b/src/pic_dump.f90
@@ -94,7 +94,8 @@
  endif
 !===============================
  kk=loc_grid_size(mype+1)
- grid_size_max=maxval(loc_grid_size(1:npe))
+ call intvec_distribute(kk,loc_grid_size,npe)  
+ grid_size_max=maxval(loc_grid_size,npe)
  lenbuff=lenbuff*grid_size_max+grid2d_size_max
 !===============================
  if(Part)then
@@ -189,7 +190,7 @@ open (lun,file='dumpRestart/'//fname//'.bin',form='unformatted',status='unknown'
 !==================
   close(lun)
  endif       !end pe0 write on fname
- if(pe0)write(6,*)'end write comm'
+ if(pe0)write(6,*)'End write Common data'
 !===========================
  allocate(send_buff(lenbuff))     !to be used for all mpi_write()
 !=====================
@@ -214,6 +215,7 @@ open (lun,file='dumpRestart/'//fname//'.bin',form='unformatted',status='unknown'
   if(MOD(mype,npe_yloc) > 0)disp_col=sum(lenw(imodz*npe_yloc+1:mype)) 
   disp_col=8*disp_col
   call mpi_write_col_dp(send_buff,lenw(mype+1),disp_col,27,fnamel_out)
+  if(pe0)write(6,*)'End write Particles data'
  endif
 !===============================
  write (fnamel_ebf,'(a9,i2.2)') 'EB-fields',imodz
@@ -233,7 +235,7 @@ open (lun,file='dumpRestart/'//fname//'.bin',form='unformatted',status='unknown'
 
  disp_col=8*imody*lenw(1+mype)
  call mpi_write_col_dp(send_buff,lenw(1+mype),disp_col,27,fnamel_out)
- if(pe0)write(6,*)'end write field'
+ if(pe0)write(6,*)'End write Fields'
  !========================
  if(envelope)then
   write (fnamel_env,'(a9,i2.2)') 'ENVfields',imodz
@@ -264,8 +266,9 @@ open (lun,file='dumpRestart/'//fname//'.bin',form='unformatted',status='unknown'
   endif
   disp_col=8*imody*lenw(1+mype)
   call mpi_write_col_dp(send_buff,lenw(mype+1),disp_col,27,fnamel_out)
- if(pe0)write(6,*)'end write env'
+ if(pe0)write(6,*)'End write Envelope'
  endif
+ !===============================
  if(Hybrid)then
   write (fnamel_fl,'(a9,i2.2)')'FL-fields',imodz
   fnamel_out='dumpRestart/'//fnamel_fl//'.bin'
@@ -299,7 +302,7 @@ open (lun,file='dumpRestart/'//fname//'.bin',form='unformatted',status='unknown'
   end do
   disp_col=8*imody*lenw(1+mype)
   call mpi_write_col_dp(send_buff,lenw(1+mype),disp_col,27,fnamel_out)
- if(pe0)write(6,*)'end write fluid'
+ if(pe0)write(6,*)'End write Fluid'
  endif
 !============== write (y,z,wghyz initial part distribution
  if(Part)then
@@ -393,7 +396,7 @@ open (lun,file='dumpRestart/'//fname//'.bin',form='unformatted',status='unknown'
  loc2d_grid_size(mype+1)=n2_loc*n3_loc
  lenbuff=ebf_cp
  if(Envelope)then
-  env1=0
+  env1_cp=0
   env_cp=size(env,4)
   if(Two_color)env1_cp=env_cp
   lenbuff=max(lenbuff,env_cp+env1_cp)

--- a/src/pic_evolve_in_time.f90
+++ b/src/pic_evolve_in_time.f90
@@ -193,7 +193,7 @@
  integer :: j2,k2,ndv
  integer :: j,k
 
- !========== inject particles from the right 
+ !========== inject particles from the right
  !   xmx is the box xmax grid value at current time after window move
  !   in Comoving frame xmax is fixed and particles are left advected
  !=================================
@@ -201,7 +201,7 @@
  !  nptx(ic) is updated in the same way both for moving window xmax
  !  or for left-advect particles with fixed xmax
  !===============================================
- 
+
  ndv=nd2+1
  do ic=1,nsp
  ! if(Comoving)then
@@ -332,25 +332,25 @@
  real(dp) :: dt_tot
  logical,parameter :: mw=.true.
  !======================
- ! In comoving x-coordinate the 
+ ! In comoving x-coordinate the
  ! [xmin <= x <= xmax] computational box is stationaty
- ! xi= (x-vb*t) => xw is left-advected 
+ ! xi= (x-vb*t) => xw is left-advected
  ! fields are left-advected in the x-grid directely in the maxw. equations
  ! particles are left-advected:
  ! xp=xp-vb*dt inside the computational box is added in the eq. of motion and
  ! for moving coordinates at each w_nst steps
  ! xpt(ix,ic)=xpt(ix,ic)-vb*w_nst*dt outside the computational box
  ! then targ_in=targ_in -vb*w_nst*dt   targ_out=targ_out-vb*w_nst*dt
- ! 
+ !
  !==================
  if(loc_it==0)return
  dt_tot=0.0
  do i=1,w_nst
   dt_tot=dt_tot+dt_loc
  enddo
- nshx=nint(dx_inv*dt_tot*vb)      !the number of grid points x-shift for each w_nst step 
+ nshx=nint(dx_inv*dt_tot*vb)      !the number of grid points x-shift for each w_nst step
  do i=1,nx+1
-  xw(i)=xw(i)-dx*nshx   !moves backwards the grid xw 
+  xw(i)=xw(i)-dx*nshx   !moves backwards the grid xw
  end do
  xw_max=xw_max-dx*nshx
  xw_min=xw_min-dx*nshx
@@ -1428,7 +1428,7 @@
      pp(1:curr_ndim)=gam_inv*pp(1:curr_ndim)  !(vx,vy)=pp/gam
     endif
     do ic=1,curr_ndim
-     flx(i,j,k,fdim+ic)=pp(ic) 
+     flx(i,j,k,fdim+ic)=pp(ic)
     end do
    end do
   end do
@@ -1447,7 +1447,7 @@
   end do
  endif
  call fill_flux_yzxbdsdata(flx,&
- i1,i2,j1,j2,k1,k2,1,fldim,3,3)  
+ i1,i2,j1,j2,k1,k2,1,fldim,3,3)
  !extends flx arrays to [j1-3--j2+3]
  call fill_ebfield_yzxbdsdata(&
  ef,i1,i2,j1,j2,k1,k2,1,nfield,2,2)
@@ -1464,7 +1464,7 @@
  call rk_fluid_density_momenta(u,flx,i1,i2,j1,j2,k1,k2,fdim,fldim,apx,apy,apz)
  !in u() adds f(u) derivatives in yrange [j1+1,j2+1]
  ! u=u0+f(u)   flx[u^{k-1} unmodified
- call add_rk_lorentz_force      !exit u=u+(E+vxB)^{k-1}  
+ call add_rk_lorentz_force      !exit u=u+(E+vxB)^{k-1}
  do ic=1,fdim
   do k=k1,k2
    do j=j1,j2
@@ -1610,7 +1610,7 @@
     endif
     call ionization_cycle(spec(ic),ebfp,np,ic,itr,0,de_inv)
    endif
-    !======== injects new electrons. 
+    !======== injects new electrons.
   end do
  endif
  !===================END IONIZATION MODULE============
@@ -1907,7 +1907,7 @@
  end do
  if(prl)call fill_ebfield_yzxbdsdata(av,i1,i2,j1,j2,k1,k2,1,1,spr_in,spl_in)
  call env_grad(av,i1,i2,j1,j2,k1,k2,ord,dx_inv,dy_inv,dz_inv)
- !Exit staggered grad|A|^2/2 in jc(2:4) or jc(2:3) 
+ !Exit staggered grad|A|^2/2 in jc(2:4) or jc(2:3)
 
  if(prl)call fill_ebfield_yzxbdsdata(av,i1,i2,j1,j2,k1,k2,2,curr_ndim+1,spr_in,spl_in)
  !=====================
@@ -1937,7 +1937,7 @@
  if(prl)call fill_ebfield_yzxbdsdata(av,i1,i2,j1,j2,k1,k2,1,1,spr,spl)
 
  call env_grad(av,i1,i2,j1,j2,k1,k2,ord,dx_inv,dy_inv,dz_inv)
- !Exit staggered grad|A|^2/2 in jc(2:4) or jc(2:3) 
+ !Exit staggered grad|A|^2/2 in jc(2:4) or jc(2:3)
 
  if(prl)call fill_ebfield_yzxbdsdata(av,i1,i2,j1,j2,k1,k2,1,curr_ndim+1,spr,spl)
 
@@ -2019,7 +2019,7 @@
  str=1
  stl=1
  if(prl)then
-  !extends flux data to j1-2,j2+2 and k1-2,k2+2 
+  !extends flux data to j1-2,j2+2 and k1-2,k2+2
   call fill_ebfield_yzxbdsdata(flx,i1,i2,j1,j2,k1,k2,1,fldim,2,2)
   call fill_ebfield_yzxbdsdata(ef,i1,i2,j1,j2,k1,k2,1,nfield,str,stl)
  endif
@@ -2028,7 +2028,7 @@
    do k=k1,k2
     do j=j1,j2
      do i=i1,i2
-      u(i,j,k,ic)=u0(i,j,k,ic)     
+      u(i,j,k,ic)=u0(i,j,k,ic)
       u0(i,j,k,ic)=0.0
      end do
     end do
@@ -2051,7 +2051,7 @@
    do k=k1,k2
     do j=j1,j2
      do i=i1,i2
-      u(i,j,k,ic)=u(i,j,k,ic)+abf_0*u0(i,j,k,ic)  
+      u(i,j,k,ic)=u(i,j,k,ic)+abf_0*u0(i,j,k,ic)
       u0(i,j,k,ic)=0.0
      end do
     end do
@@ -2099,15 +2099,15 @@
      if(flx(i,j,k,fdim)<=eps)den=0.0
      ez=wk1*(ef(i,j,k,3)+ef(i,j,k-1,3))  !Ez(i,j,k)
      b1p=wk1*(ef(i,j,k,5)+ef(i-1,j,k,5))        !by(i+1/2,j,k+1/2)
-     b1m=wk1*(ef(i,j,k-1,5)+ef(i-1,j,k-1,5))    
+     b1m=wk1*(ef(i,j,k-1,5)+ef(i-1,j,k-1,5))
      by=wk1*(b1p+b1m)                !By(i,j,k)
      b1p=wk1*(ef(i,j,k,4)+ef(i,j-1,k,4))        !bx(i,j+1/2,k+1/2)
-     b1m=wk1*(ef(i,j,k-1,4)+ef(i,j-1,k-1,4))    
+     b1m=wk1*(ef(i,j,k-1,4)+ef(i,j-1,k-1,4))
      bx=wk1*(b1p+b1m)                !Bx(i,j,k)
      vx=flx(i,j,k,fdim+1)    !vx^n
      vy=flx(i,j,k,fdim+2)    !vy^n
      vz=flx(i,j,k,fdim+3)    !vz^n
-     u0(i,j,k,1)=u0(i,j,k,1)-den*lzf*vz*by 
+     u0(i,j,k,1)=u0(i,j,k,1)-den*lzf*vz*by
      u0(i,j,k,2)=u0(i,j,k,2)+den*lzf*vz*bx
      u0(i,j,k,3)=u0(i,j,k,3)+den*lzf*(ez+vx*by-vy*bx)
      !=> u^{n+1}
@@ -2155,7 +2155,7 @@
     do i=i1,i2
      qx=ch*(flx(i,j,k,1)+flx(i+1,j,k,1))  !Dt*Jx(i+1/2,j,k)
      qy=ch*(flx(i,j,k,2)+flx(i,j+1,k,2))   !Dt*Jy(i,j+1/2,k)
-     curr(i,j,k,1)=curr(i,j,k,1)+qx        
+     curr(i,j,k,1)=curr(i,j,k,1)+qx
      curr(i,j,k,2)=curr(i,j,k,2)+qy
                         !Adds particle contributions
     end do
@@ -2317,7 +2317,7 @@
  !+++++++++++++++++++++++++++++++++++++++++++++++++++++++
    call set_env_momentum_density_flux(up,ebf,jc,ebf0,flux,i1,i2,j1,nyf,k1,nzf)
     !exit jc(1)=q^2*n/gam, jc(2:4) ponderomotive force on a grid
-    !ebf0= total fields flux(1:4)=(P,den)^n 
+    !ebf0= total fields flux(1:4)=(P,den)^n
 !============================
    call update_adam_bash_fluid_variables(up,up0,flux,ebf0,dt_loc,i1,i2,j1,nyf,k1,nzf,Ltz,initial_time)
    ! In up exit updated momenta-density variables u^{n+1}
@@ -2370,8 +2370,8 @@
    call lpf_env_positions(spec(ic),ebfp,np,dt_loc,vbeam)
    if(ompe==0.0)return
   !===========================
-  !Computes x^{n+1} 
-  ! stores 
+  !Computes x^{n+1}
+  ! stores
   !ebfp(1:3) dt*V^{n+1/2}  ebfp(4:6) old positions ebfp(7)=dt*gam_inv
   !==============================
   jc(:,:,:,:)=0.0
@@ -2615,7 +2615,7 @@
   if(nfield ==6)then
    ef_tot(:,:,:,5:6)=ef_tot(:,:,:,5:6)+efb2(:,:,:,5:6)
   endif
- end subroutine eb_fields_collect 
+ end subroutine eb_fields_collect
 !=============================
  subroutine set_eb_momentum_density_flux(uv,flx,i1,i2,j1,j2,k1,k2)
   real(dp),intent(in) :: uv(:,:,:,:)
@@ -2703,7 +2703,7 @@
                         spec(ic),ebfp,np,ic,iter_loc,0,deb_inv)
    endif
   end do
-  !======== injects new electrons, with weights equal to ion weights 
+  !======== injects new electrons, with weights equal to ion weights
  endif
 !=======================
 ! STEP 1
@@ -2728,7 +2728,7 @@
     if(initial_time)call init_lpf_momenta(spec(ic),ebfp,1,np,dt_loc,Ltz)
     call lpf_momenta_and_positions(spec(ic),ebfp,1,np,dt_loc,vb,Ltz)
 !  EXIT p^{n+1/2}, v^{n+1/2}, x^{n+1}
-!  in x^{n+1} are stored in ebfp(1:3) old x^n are stored in ebfp((4:6)  
+!  in x^{n+1} are stored in ebfp(1:3) old x^n are stored in ebfp((4:6)
 !  in ebfp(7) is stored dt_loc/gamma
    call curr_accumulate(spec(ic),ebfp,jc,1,np,iform,n_st,xm,ym,zm)
    endif
@@ -2753,7 +2753,7 @@
   !Computes fluid contribution => Dt*J_f^{n+1/2} added to particle contributions
 !  ===============  END plasma fluid section
  endif
- call advance_lpf_fields(ebf,jc,dt_loc,vbeam,i1,i2,j1,j2,k1,k2,1) 
+ call advance_lpf_fields(ebf,jc,dt_loc,vbeam,i1,i2,j1,j2,k1,k2,1)
 !==============================
 ! STEP 2
 !Advances momenta and position of bunch particles

--- a/src/pic_in.f90
+++ b/src/pic_in.f90
@@ -766,7 +766,7 @@
    do ic=1,nsp
    nptx_alloc(ic)=min(nptx(ic)+10,nx*np_per_xc(ic))
   end do
-  !========================================= 
+  !=========================================
  end select
  if(xf0 <0.)then
   do ic=1,nsp
@@ -783,7 +783,7 @@
    if(pe0)write(6,*)'new tot part number',ic,nptx(ic)
   enddo
  endif
-!============================= 
+!=============================
  do ic=1,nsp
   nptx_alloc(ic)=min(nptx(ic)+10,nx*np_per_xc(ic))
  end do
@@ -823,7 +823,7 @@
  !==================
 !=====================
  !Resets nptx(ic)=last particle coordinate inside the computational box
- !in the initial condition: for t>0  nptx(ic) updated by mowing window 
+ !in the initial condition: for t>0  nptx(ic) updated by mowing window
  do ic=1,nsp
   i1=0
   do j=1,nptx(ic)
@@ -901,7 +901,7 @@
  !==================================
  !            lx(2:3) (Z1-A1+El) central target
  nptx_loc(1:2)=(nxl(2)+nxl(3))*np_per_xc(1:2)
- !            lx(1) (Z1-A1-El) uniform with np1 density pre-plasma 
+ !            lx(1) (Z1-A1-El) uniform with np1 density pre-plasma
  nptx_loc(3:4)=nxl(1)*np_per_xc(3:4)
  !            lx(5) (Z2-A2+El) ) uniform with np2 density coating
  nptx_loc(5:6)=nxl(5)*np_per_xc(5:6)
@@ -1175,13 +1175,13 @@
  ! nsp=1-4 ordering: electrons+ Z1 ions + Z2 ions +Z3 ions
  !Weights for multilayer multisp targets
      ! first layer: electrons and Z2 (protons) ions
- wgh_sp(3)=1./real(mp_per_cell(3),dp)                   
+ wgh_sp(3)=1./real(mp_per_cell(3),dp)
  wgh_sp(4)=1./(real(ion_min(2),dp)*real(mp_per_cell(4),dp))
      ! central layer: electrons and Z1 ions
  wgh_sp(1)= j0_norm
  wgh_sp(2)= wgh_ion        !ion spec 1 (ionizable)
      ! coiating layer: electrons and Z3 (H+)
- wgh_sp(5)=1./real(mp_per_cell(5),dp)                   
+ wgh_sp(5)=1./real(mp_per_cell(5),dp)
  wgh_sp(6)=1./(real(ion_min(2),dp)*real(mp_per_cell(6),dp))
  !================================================
  !x distribution
@@ -1235,7 +1235,7 @@
   end do
  end do
  !================================
- ! WARNING : electrons and Z1 ions have the same weight 
+ ! WARNING : electrons and Z1 ions have the same weight
  ! if mp_per_cell(1)=Z1*mp_per_cell(2)
  !=================================
  xfsh=xfsh+lpx(3)+lpx(2)
@@ -1414,7 +1414,7 @@
  !============ nptx(nsp)  distribution
  nptx(1)=nptx_loc(1)+nptx_loc(4)+nptx_loc(6)  !electrons
  nptx(2)=nptx_loc(2)                          !Z1-A1 species
- nptx(3)=nptx_loc(3)                          !Z2-A2 species 
+ nptx(3)=nptx_loc(3)                          !Z2-A2 species
  nptx(4)=nptx_loc(5)+nptx_loc(7)              !Z3-A3  species in nxl(1) and nxl(5) layer
  nptx_max=maxval(nptx_loc(1:7))
  !=======================
@@ -2324,7 +2324,7 @@
   !lpx(4) second plateau density np2 and to final downramp lpx(5)
   !n_0=n_over_nc can be an average, or n0_=n1_over_nc or n0_=n2_over_nc
   !Multispecies implementation
-  ! target in models id=1 and id=2 contain (implicitely) an ion species id_sp=1 
+  ! target in models id=1 and id=2 contain (implicitely) an ion species id_sp=1
   !as a neutralizing background. If ionization is on, nsp=2 and ionizing species
   !is loaded and activated for ionization.
   !====================================
@@ -2332,7 +2332,7 @@
   !as a neutralizing background:
   ! layer(1) + layer(2) only electrons and H+ with ne=n0=n_over_nc
   ! layer(3) is a plateau with an added dopant (A1,Z1) with density
-  ! np1=n1_over_n/n0 (few %) 
+  ! np1=n1_over_n/n0 (few %)
   ! layer(4)+layer(5) as layer(1)+layer(2)
   !----------
  else
@@ -2557,7 +2557,7 @@
      write(6,*)'dmodel_id =3 not activated for one-species fluid scheme'
     endif
    return
-  !initial plateau, cos^2 bump, central plateau and exit ramp. 
+  !initial plateau, cos^2 bump, central plateau and exit ramp.
   !See model_id=4 for pic case
   case(4)
     !================ cos^2 upramp with peak np2/n0 =================
@@ -2601,7 +2601,7 @@
         cos(0.5*pi*(uu))*cos(0.5*pi*(uu))
       end do
     end if
-    !========================================= 
+    !=========================================
   end select
   if(xf0 < 0.0)then
    i1_targ=nint(dx_inv*abs(xf0))
@@ -2636,7 +2636,7 @@
  integer,intent(in) :: lp_mod
  integer :: ic,i1,i2,j1,j2,k1,k2,lp_ind
  real(dp) :: angle,shx_lp,sigm,eps,xm,tt,tau,tau1
- 
+
 
  !===========================
  ! field grid index defined on set_pgrid
@@ -2697,14 +2697,14 @@
  if(Two_color)then
   xc1_lp=xc_loc(nb_laser)-lp_offset
   xf1=xc1_lp+t1_lp
-  
+
   lp_ionz_in=xc1_lp-tau1
   lp_ionz_end=xc1_lp+tau1
   call init_lp_inc0_fields(ebf,lp1_amp,tt,t1_lp,w1_x,w1_y,xf1,om1,&
                                               lp_ind,i1,i2)
   if(pe0)write(6,'(a30,e11.4)')'two-color activated at xc1_lp=',xc1_lp
- endif 
-  
+ endif
+
 !==================================
  !==================== inject particles
  if(ny_targ>0)call part_distribute(dmodel_id,lp_end(1)+lpx(7))
@@ -2816,7 +2816,7 @@
   env1(:,:,:,:)=0.0
   xc1_lp=xc_loc(nb_laser)-lp_offset
   xf1=xc1_lp+t1_lp
-   
+
   lp_ionz_in=xc1_lp-tau1
   lp_ionz_end=xc1_lp+tau1
   if(lp_ionz_end > xm)then
@@ -2827,7 +2827,7 @@
     call init_envelope_field(&
               env1,a1,dt,tt,t1_lp,w1_x,w1_y,xf1,om1,i1,i2)
    endif
-  endif 
+  endif
  endif
  !=======================
  !==========================
@@ -2981,7 +2981,7 @@
  end subroutine beam_data
  !===================
  subroutine MPI_beam_distribute(ndm)
- 
+
  integer,intent(in) :: ndm
 
  integer :: i,ii,i1,j
@@ -3226,7 +3226,7 @@
  if(ndim==3)call FFT_Psolv(jc,gam2,ompe,nx,nx_loc,ny,ny_loc,nz,nz_loc,&
                 i1,i2b,j1,nyp,k1,nzp,ft_mod,ft_sym)
  !Solves Laplacian[pot]=ompe*rho
- !Beam potential in jc(1) 
+ !Beam potential in jc(1)
  !===================
  !====================
  call fill_ebfield_yzxbdsdata(jc,i1,i2b,j1,nyp,k1,nzp,1,2,1,1)

--- a/src/pic_in.f90
+++ b/src/pic_in.f90
@@ -2429,7 +2429,6 @@
  endif
  !=============================
  allocate(fluid_x_profile(nxf))
- allocate(fluid_yz_profile(j2,k2))
  !====================
  peak_fluid_density=1.-ratio_mpfluid
  fluid_x_profile(:)=0.0

--- a/src/pic_out.f90
+++ b/src/pic_out.f90
@@ -2172,7 +2172,7 @@
  eavg(5,nst)=dvol*ekm(4)    !Action
 !===============
  i0_lp=i1+nint(dx_inv*ekm(1))
- ekt(1:2)=0.0  
+ ekt(1:2)=0.0
  do iz=k1,nzp
   zz=0.0
   if(k1 >2 )then
@@ -2233,12 +2233,12 @@
   if(ekm(2)> 0.0)then
    ekm(1)=ekm(1)/ekm(2)    !Centroid
   endif
-  eavg1(2,nst)=ekm(1) 
+  eavg1(2,nst)=ekm(1)
   eavg1(4,nst)=field_energy*dgvol*ekm(3)   !Energy
   eavg1(5,nst)=dvol*ekm(4)    !Action
   !===============
   i0_lp=i1+nint(dx_inv*ekm(1))
-  ekt(1:2)=0.0  
+  ekt(1:2)=0.0
   do iz=k1,nzp
    zz=0.0
    if(k1 >2 )then
@@ -2429,9 +2429,9 @@
    end do
   end do
  endif
- 
+
  if(Ionization)call enb_ionz(nst,tnow,gam_min)      !select ioniz.electrons with gamma > gam_min
- 
+
  if(High_gamma)call enb_hgam(nst,tnow,gam_min)
 
 !   END PARTICLE SECTION

--- a/src/pic_out_util.f90
+++ b/src/pic_out_util.f90
@@ -72,7 +72,7 @@
   if(dt_loc > 0.0)p=nint((t_out-t_in)/dt_loc)
   track_tot_nstep=nint(real(p,dp)/real(tkjump,dp))
   ndv=size(sp_loc%part,2)
-  
+
 ! Select particles on each mpi_task
  ik=0
  select case(ndim)
@@ -114,7 +114,7 @@
  if(mype==1)last_ind=loc_tpart(1)
  if(mype>1)last_ind=sum(loc_tpart(1:mype))
  !if(loc_tpart(mype+1)>0)write(6,*)'last particle index',mype,last_ind
- do p=1,np 
+ do p=1,np
   wgh_cmp=sp_loc%part(p,ndv)
   if(part_ind >0)part_ind=part_ind+last_ind
   sp_loc%part(p,ndv)=wgh_cmp
@@ -466,7 +466,7 @@
  end subroutine prl_den_energy_interp
 !
  subroutine set_wake_potential
- 
+
  integer :: nyf,nzf,np,i1,i2,j1,k1,stl,str
  real(dp) :: xm,ym,zm
  integer :: ic,i,j,k,jj,kk,n_str,ft_mod,ft_sym
@@ -505,7 +505,7 @@
 !============== jc(1)=rho-Jx=======================
 
  ft_mod=2                                          !for cosine transform
- ft_sym=2              
+ ft_sym=2
 !-------------------------------------------
  call FFT_2D_Psolv(jc,ompe,nx,nx_loc,ny,ny_loc,nz,nz_loc,&
                                 i1,i2,j1,nyf,k1,nzf,ft_mod,ft_sym)


### PR DESCRIPTION
The problem of synchronizing every mpi process has been addressed.
Now, instead of writing a single file per core containing all the datas, we split the information by type (i.e. fields, particles, etc...) and every mpi process writes its datas on the corresponding dump via an mpi procedure.
This PR closes #49 .