### PR TITLE
Add a second (fictional) pulse to symmetrize the ionized particles phase space

### DIFF
--- a/src/ALaDyn.F90
+++ b/src/ALaDyn.F90
@@ -1118,7 +1118,9 @@
     if(Symmetrization_pulse)then
      write(60,*)' A symmetrization pulse is implied when ionizing'
      write(60,*)' The sym. formula is sin(2*pi*u)*a_symm'
-     write(60,'(a32,e11.4)')' Symmetrization amplitude a_symm',a_symm
+     if(a_symm>zero_dp)then
+      write(60,'(a32,e11.4)')' Symmetrization amplitude a_symm',a_symm
+     endif
     endif
    end if
  write(60,*)'**********TARGET PLASMA PARAMETERS***********'

--- a/src/ALaDyn.F90
+++ b/src/ALaDyn.F90
@@ -1106,15 +1106,20 @@
    endif
  write(60,*)'-----------------------------------'
    if(Ionization)then
-  write(60,*)' Field ionization model:'
-  if(ionz_model==1)write(60,*)' W_DC ADK  '
-  if(ionz_model==2)write(60,*)' W_AC= <W_DC>  ADK '
-  if(ionz_model==4)write(60,*)' W_AC ADK +BSI '
-  if(Beam)write(60,'(a24,e11.4,a6)')'  Reference max E_field ',eb_max,'(TV/m)'
-  if(Lp_active)write(60,'(a24,e11.4,a6)')'  Reference max E_field ',lp_max,'(TV/m)'
+    write(60,*)' Field ionization model:'
+    if(ionz_model==1)write(60,*)' W_DC ADK  '
+    if(ionz_model==2)write(60,*)' W_AC= <W_DC>  ADK '
+    if(ionz_model==4)write(60,*)' W_AC ADK +BSI '
+    if(Beam)write(60,'(a24,e11.4,a6)')'  Reference max E_field ',eb_max,'(TV/m)'
+    if(Lp_active)write(60,'(a24,e11.4,a6)')'  Reference max E_field ',lp_max,'(TV/m)'
     do i=1,nsp_ionz-1
-   write(60,*)' Ionization active on ion species:',species_name(atomic_number(i))
+      write(60,*)' Ionization active on ion species:',species_name(atomic_number(i))
     end do
+    if(Symmetrization_pulse)then
+     write(60,*)' A symmetrization pulse is implied when ionizing'
+     write(60,*)' The sym. formula is sin(2*pi*u)*a_symm'
+     write(60,'(a32,e11.4)')' Symmetrization amplitude a_symm',a_symm
+    endif
    end if
  write(60,*)'**********TARGET PLASMA PARAMETERS***********'
   if(Part)then

--- a/src/code_util.f90
+++ b/src/code_util.f90
@@ -43,7 +43,7 @@
  logical :: Part,part_dcmp,cmp,test,Stretch,Hybrid,Channel
  logical :: Lp_active,Lp_inject,Plane_wave,Lin_lp,Circ_lp,Relativistic,Envelope,Ions,Beam,Pbeam,Two_color
  logical :: Ionization,Wake,Solid_target,Charge_cons,G_prof,High_gamma
- logical :: Impact_ioniz,Comoving,P_tracking
+ logical :: Impact_ioniz,Comoving,P_tracking,Symmetrization_pulse
  logical :: L_intdiagnostics_pwfa,L_intdiagnostics_classic
  logical :: L_force_singlefile_output
  logical :: L_print_J_on_grid

--- a/src/grid_and_particles.f90
+++ b/src/grid_and_particles.f90
@@ -45,7 +45,7 @@
 
  real(dp) :: t0_lp,xc_lp,xf,w0_x,w0_y,lam0,a0
  real(dp) :: lp_offset,t1_lp,xc1_lp,xf1,w1_x,w1_y,lam1,a1,lp1_rad,ZR1,tau1_fwhm
- real(dp) :: lp1_amp,om1
+ real(dp) :: lp1_amp,om1,a_symm
  real(dp) :: oml,ZR,E0,lp_pow,lp_intensity,lp_xsize,lp_delay(Ref_nlas),P_c,r_c
  real(dp) :: lp_amp,lp_max,eb_max,lp_energy
 

--- a/src/ionize.f90
+++ b/src/ionize.f90
@@ -359,9 +359,9 @@
      call gasdev(u)
      spec(1)%part(ii,4)=temp(1)*u
      if(Symmetrization_pulse)then
-      call random_number(p)
-      a_symm=sp_field(n,1)*sqrt(2)
-      spec(1)%part(ii,6)=sin(2*pi*u)*a_symm
+      call random_number(u)
+      a_symm=sp_field(n,1)*sqrt(2.0)
+      spec(1)%part(ii,6)=sin(2.*pi*u)*a_symm
      else
       call gasdev(u)
       spec(1)%part(ii,6)=temp(3)*u

--- a/src/ionize.f90
+++ b/src/ionize.f90
@@ -261,7 +261,7 @@
  ii=np_el
   temp(1)=t0_pl(1)
   temp(2:3)=temp(1)
-  if(ii==0)write(6,'(a33,2I6)')'warning, no electrons before ionz',imody,imodz
+  !if(ii==0)write(6,'(a33,2I6)')'warning, no electrons before ionz',imody,imodz
   select case(curr_ndim)
   case(2)
   do n=1,np

--- a/src/ionize.f90
+++ b/src/ionize.f90
@@ -338,7 +338,11 @@
      ii=ii+1
      spec(1)%part(ii,1:2)=spec(ic)%part(n,1:2)
      call gasdev(u)
-     spec(1)%part(ii,3)=temp(1)*u
+     if(Symmetrization_pulse)then
+      spec(1)%part(ii,3)=sin(2*pi*u)*a_symm
+     else
+      spec(1)%part(ii,3)=temp(1)*u
+     endif
      call gasdev(u)
      spec(1)%part(ii,4)=sp_field(n,1)*u
      spec(1)%part(ii,id_ch)=wgh_cmp
@@ -359,7 +363,11 @@
      call gasdev(u)
      spec(1)%part(ii,4)=temp(1)*u
      call gasdev(u)
-     spec(1)%part(ii,6)=temp(3)*u
+     if(Symmetrization_pulse)then
+      spec(1)%part(ii,6)=sin(2*pi*u)*a_symm
+     else
+      spec(1)%part(ii,6)=temp(3)*u
+     endif
      call gasdev(u)
      spec(1)%part(ii,5)=sp_field(n,1)*u
      spec(1)%part(ii,id_ch)=wgh_cmp

--- a/src/ionize.f90
+++ b/src/ionize.f90
@@ -338,11 +338,7 @@
      ii=ii+1
      spec(1)%part(ii,1:2)=spec(ic)%part(n,1:2)
      call gasdev(u)
-     if(Symmetrization_pulse)then
-      spec(1)%part(ii,3)=sin(2*pi*u)*a_symm
-     else
-      spec(1)%part(ii,3)=temp(1)*u
-     endif
+     spec(1)%part(ii,3)=temp(1)*u
      call gasdev(u)
      spec(1)%part(ii,4)=sp_field(n,1)*u
      spec(1)%part(ii,id_ch)=wgh_cmp
@@ -362,10 +358,12 @@
      spec(1)%part(ii,1:3)=spec(ic)%part(n,1:3)
      call gasdev(u)
      spec(1)%part(ii,4)=temp(1)*u
-     call gasdev(u)
      if(Symmetrization_pulse)then
+      call random_number(p)
+      a_symm=sp_field(n,1)*sqrt(2)
       spec(1)%part(ii,6)=sin(2*pi*u)*a_symm
      else
+      call gasdev(u)
       spec(1)%part(ii,6)=temp(3)*u
      endif
      call gasdev(u)

--- a/src/read_input.f90
+++ b/src/read_input.f90
@@ -67,7 +67,7 @@
   mass_number,t0_pl,ppc,np_per_xc,np_per_yc,np_per_zc,lpx,lpy,&
   n_over_nc,np1,np2,r_c,L_disable_rng_seed
  NAMELIST/LASER/G_prof,nb_laser,t0_lp,xc_lp,tau_fwhm,w0_y,a0,lam0,lp_delay,&
- lp_offset,t1_lp,tau1_fwhm,w1_y,a1,lam1
+ lp_offset,t1_lp,tau1_fwhm,w1_y,a1,lam1,Symmetrization_pulse,a_symm
  NAMELIST/MOVING_WINDOW/w_sh,wi_time,wf_time,w_speed
  NAMELIST/OUTPUT/nouts,iene,nvout,nden,npout,nbout,jump,pjump,gam_min,xp0_out,xp1_out,yp_out,tmax,cfl, &
   new_sim,id_new,dump,P_tracking,L_force_singlefile_output,time_interval_dumps,L_print_J_on_grid, &
@@ -111,6 +111,8 @@
  call consistency_check_number_of_particles_comp
 
  !--- reading laser parameters ---!
+ Symmetrization_pulse= .false.
+ a_symm=0.
  open(nml_iounit,file=input_namelist_filename, status='old')
  read(nml_iounit,LASER,iostat=nml_ierr)
  nml_error_message='LASER'
@@ -303,7 +305,7 @@ end subroutine read_nml_integrated_background_diagnostic
   mass_number,t0_pl,ppc,np_per_xc,np_per_yc,np_per_zc,lpx,lpy,&
   n_over_nc,np1,np2,r_c
  NAMELIST/LASER/G_prof,nb_laser,t0_lp,xc_lp,tau_fwhm,w0_y,a0,lam0,lp_delay,&
-  lp_offset,t1_lp,tau1_fwhm,w1_y,a1,lam1
+  lp_offset,t1_lp,tau1_fwhm,w1_y,a1,lam1,Symmetrization_pulse,a_symm
  NAMELIST/MOVING_WINDOW/w_sh,wi_time,wf_time,w_speed
  NAMELIST/OUTPUT/nouts,iene,nvout,nden,npout,nbout,jump,pjump,gam_min,xp0_out,xp1_out,yp_out,tmax,cfl, &
   new_sim,id_new,dump,P_tracking,L_force_singlefile_output,time_interval_dumps,L_print_J_on_grid, &


### PR DESCRIPTION
We add a special flag to enable the action of a symmetrization pulse, copropagating with the ionizing ones and perpendicularly polarized with respect to them.
At the present time, the working point of this pulse is taylored onto a specific request of the REMPI acceleration scheme, but it can be easily generalized if needed.