### PR TITLE
Add logical flag to enable ionization for specific envelope pulse

### DIFF
--- a/src/ALaDyn.F90
+++ b/src/ALaDyn.F90
@@ -990,8 +990,8 @@
    write(60,'(a6,e11.4,a6,e11.4,a6,e11.4)')'  Dx =',dx,'  Dy =',dy,'  Dz =',dz
   endif
  if(Stretch)then
-  write(60,*)'  y=tang(a*xi) stretched layers on the transverse coordinates'
-  write(60,'(a20,i6,2e11.4)')'  stretched grid size=',ny_stretch,y(ny_stretch+1)
+  write(60,*)' y=tan(a*xi) stretched layers on the transverse coordinates'
+  write(60,'(a22,i6,a2,2e11.4)')'  stretched grid size=',ny_stretch,'  ',y(ny_stretch+1)
  endif
  write(60,*)'***************PHYSICAL MODEL**********************'
  if(model_id <4)then
@@ -1057,6 +1057,7 @@
   write(60,'(a9,e13.3,a4)')'  Power = ',lp_pow,'(TW)'
   write(60,'(a10,e13.3,a3)')'  Energy= ',lp_energy,'(J)'
   write(60,'(a30,i4)')'  Number of main laser pulses= ',nb_laser
+  if(.not.Enable_ionization(1))write(60,*)' WARNING: Ionization disabled for the main pulse'
   if(nb_laser >1)then
    do i=2,nb_laser
     write(60,'(a23,i2,a5,i2,a10,f5.2)')'  Distance between the ',i-1,' and ',i,'&
@@ -1076,6 +1077,7 @@
    write(60,'(a29,e11.4)')'  Diffraction length Z_Rayl= ',ZR1
    write(60,'(a25,f5.2)')'  Strength parameter a0= ',a1
    write(60,'(a33,f5.2,a6)')'  Max transverse field at focus= ',E0*a1*om1,'(TV/m)'
+   if(.not.Enable_ionization(2))write(60,*)' WARNING: Ionization disabled for the injection pulse'
   endif
  endif
  if(Hybrid)then

--- a/src/ALaDyn.F90
+++ b/src/ALaDyn.F90
@@ -1126,7 +1126,7 @@
     endif
    end if
  write(60,*)'**********TARGET PLASMA PARAMETERS***********'
-  if(Part)then
+  if(Part.or.Hybrid)then
    write(60,'(a26,e11.4,a10)')'  Electron number density ',n0_ref,'[10^18/cc]'
    write(60,'(a21,f5.2)')'  Plasma wavelength= ',lambda_p
    write(60,'(a20,e11.4)')' Chanelling fact  = ',chann_fact

--- a/src/code_util.f90
+++ b/src/code_util.f90
@@ -52,5 +52,6 @@
  logical :: L_disable_rng_seed
  logical :: L_intdiagnostics_background
  logical :: L_env_modulus
+ logical :: Enable_ionization(2)
 
  end module code_util

--- a/src/ionize.f90
+++ b/src/ionize.f90
@@ -325,7 +325,7 @@
   temp(1)=t0_pl(1)
   temp(2:3)=temp(1)
   ii=np_el
-  if(ii==0)write(6,'(a33,2I6)')'warning, no electrons before ionz',imody,imodz
+  !if(ii==0)write(6,'(a33,2I6)')'warning, no electrons before ionz',imody,imodz
   select case(curr_ndim)
   case(2)
   do n=1,np

--- a/src/read_input.f90
+++ b/src/read_input.f90
@@ -67,7 +67,7 @@
   mass_number,t0_pl,ppc,np_per_xc,np_per_yc,np_per_zc,lpx,lpy,&
   n_over_nc,np1,np2,r_c,L_disable_rng_seed
  NAMELIST/LASER/G_prof,nb_laser,t0_lp,xc_lp,tau_fwhm,w0_y,a0,lam0,lp_delay,&
- lp_offset,t1_lp,tau1_fwhm,w1_y,a1,lam1,Symmetrization_pulse,a_symm
+ lp_offset,t1_lp,tau1_fwhm,w1_y,a1,lam1,Symmetrization_pulse,a_symm,Enable_ionization
  NAMELIST/MOVING_WINDOW/w_sh,wi_time,wf_time,w_speed
  NAMELIST/OUTPUT/nouts,iene,nvout,nden,npout,nbout,jump,pjump,gam_min,xp0_out,xp1_out,yp_out,tmax,cfl, &
   new_sim,id_new,dump,P_tracking,L_force_singlefile_output,time_interval_dumps,L_print_J_on_grid, &
@@ -113,6 +113,7 @@
  !--- reading laser parameters ---!
  Symmetrization_pulse= .false.
  a_symm=0.
+ Enable_ionization(:)=.true.
  open(nml_iounit,file=input_namelist_filename, status='old')
  read(nml_iounit,LASER,iostat=nml_ierr)
  nml_error_message='LASER'
@@ -305,7 +306,7 @@ end subroutine read_nml_integrated_background_diagnostic
   mass_number,t0_pl,ppc,np_per_xc,np_per_yc,np_per_zc,lpx,lpy,&
   n_over_nc,np1,np2,r_c
  NAMELIST/LASER/G_prof,nb_laser,t0_lp,xc_lp,tau_fwhm,w0_y,a0,lam0,lp_delay,&
-  lp_offset,t1_lp,tau1_fwhm,w1_y,a1,lam1,Symmetrization_pulse,a_symm
+  lp_offset,t1_lp,tau1_fwhm,w1_y,a1,lam1,Symmetrization_pulse,a_symm,Enable_ionization
  NAMELIST/MOVING_WINDOW/w_sh,wi_time,wf_time,w_speed
  NAMELIST/OUTPUT/nouts,iene,nvout,nden,npout,nbout,jump,pjump,gam_min,xp0_out,xp1_out,yp_out,tmax,cfl, &
   new_sim,id_new,dump,P_tracking,L_force_singlefile_output,time_interval_dumps,L_print_J_on_grid, &


### PR DESCRIPTION
Is now possible to assign the flag Enable_ionization to the laser pulse to decide if it participates in the ionization process. This is particularly useul when implying many laser pulses and one is only interested in the ionization of only few of them.