### PR TITLE
Marconi knl compilation scripts updated to intel 2018

### DIFF
--- a/scripts/build/cmake.marconi.knl
+++ b/scripts/build/cmake.marconi.knl
@@ -3,15 +3,15 @@
 module purge
 
 module load env-knl
-module load intel
-module load intelmpi
-module load boost
-module load mkl
+module load intel/pe-xe-2018--binary
+module load intelmpi/2018--binary
+module load boost/1.66.0--intelmpi--2018--binary
+module load mkl/2018--binary
 module load cmake
 
-export CC=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/icc
-export CXX=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/icpc
-export FC=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/ifort
+#export CC=/cineca/prod/opt/compilers/intel/pe-xe-2018/binary/bin/icc
+#export CXX=/cineca/prod/opt/compilers/intel/pe-xe-2018/binary/bin/icpc
+#export FC=/cineca/prod/opt/compilers/intel/pe-xe-2018/binary/bin/ifort
 export CLINKER=$CXX
 
 mkdir -p build ; cd build

--- a/scripts/build/cmake.marconi.knl.debug
+++ b/scripts/build/cmake.marconi.knl.debug
@@ -3,15 +3,15 @@
 module purge
 
 module load env-knl
-module load intel
-module load intelmpi
-module load boost
-module load mkl
+module load intel/pe-xe-2018--binary
+module load intelmpi/2018--binary
+module load boost/1.66.0--intelmpi--2018--binary
+module load mkl/2018--binary
 module load cmake
 
-export CC=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/icc
-export CXX=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/icpc
-export FC=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/ifort
+#export CC=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/icc
+#export CXX=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/icpc
+#export FC=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/ifort
 export CLINKER=$CXX
 
 mkdir -p build ; cd build

--- a/scripts/build/cmake.marconi.knl.debug.fftw
+++ b/scripts/build/cmake.marconi.knl.debug.fftw
@@ -3,15 +3,15 @@
 module purge
 
 module load env-knl
-module load intel
-module load intelmpi
-module load boost
-module load fftw
+module load intel/pe-xe-2018--binary
+module load intelmpi/2018--binary
+module load boost/1.66.0--intelmpi--2018--binary
+module load fftw/3.3.7--intelmpi--2018--binary
 module load cmake
 
-export CC=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/icc
-export CXX=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/icpc
-export FC=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/ifort
+#export CC=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/icc
+#export CXX=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/icpc
+#export FC=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/ifort
 export CLINKER=$CXX
 
 mkdir -p build ; cd build

--- a/scripts/build/cmake.marconi.knl.fftw
+++ b/scripts/build/cmake.marconi.knl.fftw
@@ -3,15 +3,15 @@
 module purge
 
 module load env-knl
-module load intel
-module load intelmpi
-module load boost
-module load fftw
+module load intel/pe-xe-2018--binary
+module load intelmpi/2018--binary
+module load boost/1.66.0--intelmpi--2018--binary
+module load fftw/3.3.7--intelmpi--2018--binary
 module load cmake
 
-export CC=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/icc
-export CXX=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/icpc
-export FC=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/ifort
+#export CC=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/icc
+#export CXX=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/icpc
+#export FC=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/ifort
 export CLINKER=$CXX
 
 mkdir -p build ; cd build

--- a/scripts/run/marconi-68-knl-fftw.cmd
+++ b/scripts/run/marconi-68-knl-fftw.cmd
@@ -9,9 +9,9 @@
 module purge
 
 module load env-knl
-module load intel
-module load intelmpi
-module load boost
-module load fftw
+module load intel/pe-xe-2018--binary
+module load intelmpi/2018--binary
+module load boost/1.66.0--intelmpi--2018--binary
+module load fftw/3.3.7--intelmpi--2018--binary
 
 mpirun ./ALaDyn >> opic.txt 2>> epic.txt

--- a/scripts/run/marconi-68-knl.cmd
+++ b/scripts/run/marconi-68-knl.cmd
@@ -9,9 +9,9 @@
 module purge
 
 module load env-knl
-module load intel
-module load intelmpi
-module load boost
-module load mkl
+module load intel/pe-xe-2018--binary
+module load intelmpi/2018--binary
+module load boost/1.66.0--intelmpi--2018--binary
+module load mkl/2018--binary
 
 mpirun ./ALaDyn >> opic.txt 2>> epic.txt


### PR DESCRIPTION
Marconi Knl script updated to Intel 2018 compiler.
Update to Intel 2019 is still impossible due to some missing compatible libraries.