### PR TITLE
Equal sign added to include injection of the single particle

### DIFF
--- a/src/pic_evolve_in_time.f90
+++ b/src/pic_evolve_in_time.f90
@@ -229,7 +229,7 @@
  !==========================
  ! Partcles to be injected have index ix [i1,i2]
  !============================
-  if(i2 > i1)then
+  if(i2 >= i1)then
  !==========================
    npt_inj(ic)=0
  !=========== injects particles with coordinates index i1<= ix <=i2


### PR DESCRIPTION
Fixed bug when moving window was not injecting particle distribution correctly. If the longitudinal number of particles to be injected was N=1, code did not enter in the injection routine.
This closes #79 .