### PR TITLE
Marconi compilation scripts updated

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
       STRING "Choose the type of build." FORCE)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
-    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+    "Debug" "Release" "MinSizeRel" "RelWithDebInfo" "Profiling")
 endif()
 
 list(APPEND ALaDyn_Fortran_sources
@@ -92,6 +92,7 @@ elseif(Fortran_COMPILER_NAME MATCHES "ifor*" OR Fortran_COMPILER_NAME MATCHES "f
   string(APPEND CMAKE_CXX_COMPILE_FLAGS " -diag-enable warn")
   string(APPEND CMAKE_Fortran_FLAGS_RELEASE " -real-size 64")
   string(APPEND CMAKE_Fortran_FLAGS_DEBUG   " -real-size 64 -diag-enable warn")
+  string(APPEND CMAKE_Fortran_FLAGS_PROFILING "-g -O2 -qopt-report=5 -qopt-report-file=comp_report_out -qopt-report-per-object -real-size 64")
   if(MARCONI_KNL)
     string(APPEND CMAKE_CXX_COMPILE_FLAGS " -xMIC-AVX512")
     string(APPEND CMAKE_Fortran_FLAGS_RELEASE " -xMIC-AVX512 -O3")

--- a/scripts/build/cmake.marconi.intel
+++ b/scripts/build/cmake.marconi.intel
@@ -2,15 +2,15 @@
 
 module purge
 
-module load intel
-module load intelmpi
-module load boost
-module load mkl
+module load intel/pe-xe-2018--binary
+module load intelmpi/2018--binary
+module load boost/1.66.0--intelmpi--2018--binary
+module load mkl/2018--binary
 module load cmake
 
-export CC=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/icc
-export CXX=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/icpc
-export FC=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/ifort
+export CC=/cineca/prod/opt/compilers/intel/pe-xe-2018/binary/bin/icc
+export CXX=/cineca/prod/opt/compilers/intel/pe-xe-2018/binary/bin/icpc
+export FC=/cineca/prod/opt/compilers/intel/pe-xe-2018/binary/bin/ifort
 export CLINKER=$CXX
 
 mkdir -p build ; cd build

--- a/scripts/build/cmake.marconi.intel.profiling
+++ b/scripts/build/cmake.marconi.intel.profiling
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+module purge
+
+module load intel/pe-xe-2018--binary
+module load intelmpi/2018--binary
+module load boost/1.66.0--intelmpi--2018--binary
+module load mkl/2018--binary
+module load cmake
+
+export CC=/cineca/prod/opt/compilers/intel/pe-xe-2018/binary/bin/icc
+export CXX=/cineca/prod/opt/compilers/intel/pe-xe-2018/binary/bin/icpc
+export FC=/cineca/prod/opt/compilers/intel/pe-xe-2018/binary/bin/ifort
+export CLINKER=$CXX
+
+mkdir -p build ; cd build
+cmake .. -DCMAKE_BUILD_TYPE="Profiling" -DCMAKE_LINKER=$CLINKER -DBoost_NO_BOOST_CMAKE=ON -DCMAKE_Fortran_COMPILER=$FC
+cmake --build . --target install
+cd ..

--- a/scripts/build/cmake.marconi.knl
+++ b/scripts/build/cmake.marconi.knl
@@ -3,15 +3,15 @@
 module purge
 
 module load env-knl
-module load intel
-module load intelmpi
-module load boost
-module load mkl
+module load intel/pe-xe-2018--binary
+module load intelmpi/2018--binary
+module load boost/1.66.0--intelmpi--2018--binary
+module load mkl/2018--binary
 module load cmake
 
-export CC=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/icc
-export CXX=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/icpc
-export FC=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/ifort
+export CC=/cineca/prod/opt/compilers/intel/pe-xe-2018/binary/bin/icc
+export CXX=/cineca/prod/opt/compilers/intel/pe-xe-2018/binary/bin/icpc
+export FC=/cineca/prod/opt/compilers/intel/pe-xe-2018/binary/bin/ifort
 export CLINKER=$CXX
 
 mkdir -p build ; cd build

--- a/scripts/build/cmake.marconi.knl.debug
+++ b/scripts/build/cmake.marconi.knl.debug
@@ -3,15 +3,15 @@
 module purge
 
 module load env-knl
-module load intel
-module load intelmpi
-module load boost
-module load mkl
+module load intel/pe-xe-2018--binary
+module load intelmpi/2018--binary
+module load boost/1.66.0--intelmpi--2018--binary
+module load mkl/2018--binary
 module load cmake
 
-export CC=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/icc
-export CXX=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/icpc
-export FC=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/ifort
+export CC=/cineca/prod/opt/compilers/intel/pe-xe-2018/binary/bin/icc
+export CXX=/cineca/prod/opt/compilers/intel/pe-xe-2018/binary/bin/icpc
+export FC=/cineca/prod/opt/compilers/intel/pe-xe-2018/binary/bin/ifort
 export CLINKER=$CXX
 
 mkdir -p build ; cd build

--- a/scripts/build/cmake.marconi.knl.debug.fftw
+++ b/scripts/build/cmake.marconi.knl.debug.fftw
@@ -2,19 +2,21 @@
 
 module purge
 
+module load profile/base
+module load profile/knl
 module load env-knl
-module load intel
-module load intelmpi
-module load boost
-module load fftw
+module load intel/pe-xe-2018--binary
+module load intelmpi/2018--binary
+module load boost/1.66.0--intelmpi--2018--binary
+module load fftw/3.3.7_knl--intelmpi--2018--binary
 module load cmake
 
-export CC=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/icc
-export CXX=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/icpc
-export FC=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/ifort
+export CC=/cineca/prod/opt/compilers/intel/pe-xe-2018/binary/bin/icc
+export CXX=/cineca/prod/opt/compilers/intel/pe-xe-2018/binary/bin/icpc
+export FC=/cineca/prod/opt/compilers/intel/pe-xe-2018/binary/bin/ifort
 export CLINKER=$CXX
 
 mkdir -p build ; cd build
-cmake .. -DCMAKE_BUILD_TYPE="Debug" -DFORCE_FFTW:BOOL=ON -DFFTW_ROOT_DIR=/cineca/prod/opt/libraries/fftw/3.3.4/intelmpi--2017--binary/ -DMARCONI_KNL:BOOL=TRUE -DCMAKE_LINKER=$CLINKER -DBoost_NO_BOOST_CMAKE=ON -DCMAKE_Fortran_COMPILER=$FC
+cmake .. -DCMAKE_BUILD_TYPE="Debug" -DFORCE_FFTW:BOOL=ON -DFFTW_ROOT_DIR=/cineca/prod/opt/libraries/fftw/3.3.7_knl/intelmpi--2018--binary/ -DMARCONI_KNL:BOOL=TRUE -DCMAKE_LINKER=$CLINKER -DBoost_NO_BOOST_CMAKE=ON -DCMAKE_Fortran_COMPILER=$FC
 cmake --build . --target install
 cd ..

--- a/scripts/build/cmake.marconi.knl.fftw
+++ b/scripts/build/cmake.marconi.knl.fftw
@@ -2,19 +2,21 @@
 
 module purge
 
+module load profile/base
+module load profile/knl
 module load env-knl
-module load intel
-module load intelmpi
-module load boost
-module load fftw
+module load intel/pe-xe-2018--binary
+module load intelmpi/2018--binary
+module load boost/1.66.0--intelmpi--2018--binary
+module load fftw/3.3.7_knl--intelmpi--2018--binary
 module load cmake
 
-export CC=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/icc
-export CXX=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/icpc
-export FC=/cineca/prod/opt/compilers/intel/pe-xe-2017/binary/bin/ifort
+export CC=/cineca/prod/opt/compilers/intel/pe-xe-2018/binary/bin/icc
+export CXX=/cineca/prod/opt/compilers/intel/pe-xe-2018/binary/bin/icpc
+export FC=/cineca/prod/opt/compilers/intel/pe-xe-2018/binary/bin/ifort
 export CLINKER=$CXX
 
 mkdir -p build ; cd build
-cmake .. -DMARCONI_KNL:BOOL=TRUE -DFORCE_FFTW:BOOL=ON -DFFTW_ROOT_DIR=/cineca/prod/opt/libraries/fftw/3.3.4/intelmpi--2017--binary/ -DCMAKE_LINKER=$CLINKER -DBoost_NO_BOOST_CMAKE=ON -DCMAKE_Fortran_COMPILER=$FC
+cmake .. -DFORCE_FFTW:BOOL=ON -DFFTW_ROOT_DIR=/cineca/prod/opt/libraries/fftw/3.3.7_knl/intelmpi--2018--binary/ -DMARCONI_KNL:BOOL=TRUE -DCMAKE_LINKER=$CLINKER -DBoost_NO_BOOST_CMAKE=ON -DCMAKE_Fortran_COMPILER=$FC
 cmake --build . --target install
 cd ..

--- a/scripts/build/cmake.marconi.knl.profiling
+++ b/scripts/build/cmake.marconi.knl.profiling
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+module purge
+
+module load env-knl
+module load intel/pe-xe-2018--binary
+module load intelmpi/2018--binary
+module load boost/1.66.0--intelmpi--2018--binary
+module load mkl/2018--binary
+module load cmake
+
+export CC=/cineca/prod/opt/compilers/intel/pe-xe-2018/binary/bin/icc
+export CXX=/cineca/prod/opt/compilers/intel/pe-xe-2018/binary/bin/icpc
+export FC=/cineca/prod/opt/compilers/intel/pe-xe-2018/binary/bin/ifort
+export CLINKER=$CXX
+
+mkdir -p build ; cd build
+cmake .. -DCMAKE_BUILD_TYPE="Profiling" -DMARCONI_KNL:BOOL=TRUE -DCMAKE_LINKER=$CLINKER -DBoost_NO_BOOST_CMAKE=ON -DCMAKE_Fortran_COMPILER=$FC
+cmake --build . --target install
+cd ..

--- a/scripts/run/marconi-68-knl-fftw.cmd
+++ b/scripts/run/marconi-68-knl-fftw.cmd
@@ -8,10 +8,12 @@
 
 module purge
 
+module load profile/base
+module load profile/knl
 module load env-knl
-module load intel
-module load intelmpi
-module load boost
-module load fftw
+module load intel/pe-xe-2018--binary
+module load intelmpi/2018--binary
+module load boost/1.66.0--intelmpi--2018--binary
+module load fftw/3.3.7_knl--intelmpi--2018--binary
 
 mpirun ./ALaDyn >> opic.txt 2>> epic.txt

--- a/scripts/run/marconi-68-knl.cmd
+++ b/scripts/run/marconi-68-knl.cmd
@@ -9,9 +9,9 @@
 module purge
 
 module load env-knl
-module load intel
-module load intelmpi
-module load boost
-module load mkl
+module load intel/pe-xe-2018--binary
+module load intelmpi/2018--binary
+module load boost/1.66.0--intelmpi--2018--binary
+module load mkl/2018--binary
 
 mpirun ./ALaDyn >> opic.txt 2>> epic.txt


### PR DESCRIPTION
In this PR

- Marconi compilation scripts have been updated to `intel/2018`
- Compilation script to enable the `vtune` profiler on Marconi added