### PR TITLE
Add ion concentration

### DIFF
--- a/doc/NAMELIST_GUIDE.md
+++ b/doc/NAMELIST_GUIDE.md
@@ -116,6 +116,12 @@ With those parameters, the full box size (in μm) is: `Lx = nx / k0`, `Ly = yx_r
  np_per_yc(4)     = 4,
  np_per_yc(5)     = 4,
  np_per_yc(6)     = 4,
+ concentration(1) = 0.5,
+ concentration(2) = 0.5,
+ concentration(3) = 0,
+ concentration(4) = 0,
+ concentration(5) = 0,
+ concentration(6) = 0,
  lpx(1)           = 0.0,
  lpx(2)           = 0.0,
  lpx(3)           = 2.0,
@@ -167,6 +173,7 @@ Copper    (atomic_number = 29) - mass_number = 63.54
   + `dmodel_id=1` : i=1 indicates the number of electrons, i=2 the number of macroparticles of Z_1 species, i=3 the number of macroparticles of Z_2 species and i=4 the number of macroparticles of Z_3 species.
   + `dmodel_id=3,4` : i=1,2 are the number of electrons and ions per cell along x/y in the bulk, i=3,4 refer to the front layer and i=5,6 to the contaminants.
 + `np_per_yc(i)`: the same as `np_per_xc`, this describes the number of particles per cell along transverse directions (valid also for *z* for 3D simulations)
++ `concentration(i)`: concentration of the *i-th* ion species. The sum of all the concentrations must be 1 to result in a consistent description.
 + `dmodel_id=1`
     + `lpx(1)` is the length [μm] of the upstream layer (foam or preplasma), having density `n1/nc`
     + `lpx(2)` is the length [μm] of the ramp (linear or exponential depending on the `mdl`) connecting the upstream layer with the central one (made with bulk particles)
@@ -176,6 +183,9 @@ Copper    (atomic_number = 29) - mass_number = 63.54
     + `lpx(7)` is the offset [μm] between the end of the laser and the beginning of the target (if zero, the target starts right at the end of the laser pulse). In the gaussian case, the end of the pulse is defined as the center position + the FWHM. The offset is calculated *before* laser rotation, so mind the transverse size if `incid_angle ≠ 0`, in order to avoid laser initialization *inside the target*.
     + `n_over_nc` is the density in the central layer (bulk)
     + *LWFA* case: density is in units of critical density
+        + If `nsp=1`, `n_over_nc` is the plasma density
+        + If `nsp>1`, `n_over_nc` is the density of the neutral gas, *e.g.* the gas jet density before the plasma formation.
+        If the background atoms are already ionized, the initial plasma density is computed accordingly.
     + *PWFA* case: the density is in units of (a nominal value) nc=1e18 cm-3
     + `np1` is the density in the upstream layer (foam/preplasma)
     + `np2` is the density in the downstream layer (contaminants)
@@ -309,7 +319,7 @@ Copper    (atomic_number = 29) - mass_number = 63.54
   + in general it writes *only* the phase space of the *n-th* species, with `n=npv`; if `n=npv>nps`, it writes the phase spaces of all the particle species
 + `jump`: jump on grid points; if `jump=2`, it means that each processor is going to write only one point every two. Mind that it's extremely important that `jump` is a divisor of the number of grid points *per processor*, otherwise the grid output will be corrupted
 + `pjump`: jump on particles; if `pjump=2`, it means that each processor is going to write the phase space of just one particle every two.
-+ `xp0_out`, `xp1_out` and `yp_out` only particles contained inside the box defined by `xp0 < x < xp1`, `|y| < yp_out` will be printed in the output
++ `xp0_out`, `xp1_out` and `yp_out` only particles contained inside the box defined by `xp0 < x-w_speed t < xp1`, `|y| < yp_out` will be printed in the output
 + `tmax` is the relative time (in μm, because it is multiplied by *c*) that the simulation is going to be evolved. Being relative, it's going to be added to the time eventually already reached before the restart. To obtain the time in fs, you have to divide it by 0.299792458 [speed of light in μm/fs]
 + `cfl` is the Courant–Friedrichs–Lewy parameter ( [Wikipedia CFL-parameter page](http://en.wikipedia.org/wiki/Courant%E2%80%93Friedrichs%E2%80%93Lewy_condition) )
 + `new_sim`: identifies if a simulation is new `new=0` (data is recreated from initial conditions) or if it is a restart `new=1` (dump are going to be read)

--- a/examples/input_lwfa.nml
+++ b/examples/input_lwfa.nml
@@ -55,6 +55,7 @@
   np_per_yc(4)     = 1,
   np_per_yc(5)     = 1,
   np_per_yc(6)     = 1,
+  concentration(1) = 1,
   lpx(1)           = 0.,
   lpx(2)           = 50.,
   lpx(3)           = 400.,
@@ -62,6 +63,7 @@
   lpx(5)           = 0.0,
   lpx(6)           = 0.0,
   lpx(7)           = 15.0,
+  incid_angle      = 0.0,
   lpy(1)           = 0.0,
   lpy(2)           = 0.0,
   n_over_nc        = 5.75e-4,
@@ -78,13 +80,21 @@
   w0_y             = 20.0,
   a0               = 2.0,
   lam0             = 0.8,
-  lp_delay         = 20.59
+  y0_cent(1)       = 0.0,
+  z0_cent(1)       = 0.0,
+  Enable_ionization(1)=.true.,
+  lp_delay(1)         = 20.59
   lp_offset        = 0,
   t1_lp            = 200.0,
   tau1_fwhm        = 24.74,
   w1_y             = 3.5,
   a1               = 0.45,
   lam1             = 0.4,
+  y1_cent          = 0.0,
+  z1_cent          = 0.0,
+  Enable_ionization(2)=.true.,
+  Symmetrization_pulse = .false.,
+  a_symm_rat       = 1.35,
 /
 
 &MOVING_WINDOW
@@ -113,10 +123,10 @@
   id_new           = 0,
   dump             = 0,
   L_env_modulus    =.true.,
-  P_tracking       =.true.,
 /
 
 &TRACKING
+  P_tracking       =.true.,
   nkjump           = 128,
   tkjump           = 100,
   txmin            = 53.,

--- a/src/all_param.f90
+++ b/src/all_param.f90
@@ -301,7 +301,7 @@
   if(mp_per_cell(1)==0)ratio_mpfluid=0.0
   if(ny_targ==0)ratio_mpfluid=0.0
  endif
- !j0_norm=j0_norm*ratio_mpfluid
+ j0_norm=j0_norm*ratio_mpfluid
  !========================== multispecies
  ! mass-charge parameters four species: three ion species+ electrons
  ! Ions charges defined by initial conditions.
@@ -403,6 +403,7 @@
    if(n_plasma<epsilon)then
     np_per_xc(1)=0
     np_per_yc(1)=0
+    n_plasma=zero_dp
    end if
   else if(nsp==1)then
    n_plasma=one_dp

--- a/src/all_param.f90
+++ b/src/all_param.f90
@@ -320,11 +320,19 @@
  end do
   Lorentz_fact(1:4)=mass_rat(1:4)  !for (E,B) fields in mc2/e/l0(mu) unit
   E0=electron_mass
+ !=====================================
+ ! Check species molecular number
+ !=====================================
+ if(nsp>1)then
+  do i=1,nsp-1
+   call set_atoms_per_molecule(atomic_number(i),N_mol_atoms(i))
+  end do
+ end if
  !======================================
  ! Set ionization param
  ! WARNING  ion ordering in input data must set ionizing species first
  !==========================================================
- wgh_ion=j0_norm
+ !wgh_ion=j0_norm
  nsp_ionz=1
  if(nsp > 1)then
   do i=1, nsp-1          !index of ionizing ion species 2,.. nsp_ionz <= nsp
@@ -337,8 +345,8 @@
   if(ionz_lev >0)Ionization=.true.
   if(Ionization) call set_ionization_coeff(atomic_number,nsp_ionz)
   !uses ion index 1,2,,,nsp-1
-  wgh_ion=1./(real(mp_per_cell(2),dp))
-  if(ion_min(1)>1)wgh_ion=1./(real(ion_min(1),dp)*real(mp_per_cell(2),dp))
+   wgh_ion=concentration(1)/(real(mp_per_cell(2),dp))
+  !if(ion_min(1)>1)wgh_ion=1./(real(ion_min(1),dp)*real(mp_per_cell(2),dp))
  endif
 !=======Moving window
  if(w_speed < 0.0)then
@@ -387,6 +395,18 @@
 !====================================
 !=======================
   ! Code Units for laser fields
+  n_plasma=0
+  if(nsp>1)then
+   do i=1,nsp-1
+    n_plasma=n_plasma+concentration(i)*N_mol_atoms(i)*ion_min(i)
+   end do
+   if(n_plasma<epsilon)then
+    np_per_xc(1)=0
+    np_per_yc(1)=0
+   end if
+  else if(nsp==1)then
+   n_plasma=one_dp
+  end if
   ncrit=pi/(rc0*lam0*lam0)      !critical density in units n0=10^21/cm^3=10^9/mu^3
   n0_ref= 1.e03*ncrit*n_over_nc ! reference density in 10^18/cc=10^6/mu^3 unit
   nm_fact=ncrit*(1.e+9)         ! critical density (1/mu^3)

--- a/src/all_param.f90
+++ b/src/all_param.f90
@@ -395,18 +395,20 @@
 !====================================
 !=======================
   ! Code Units for laser fields
-  n_plasma=0
-  if(nsp>1)then
-   do i=1,nsp-1
-    n_plasma=n_plasma+concentration(i)*N_mol_atoms(i)*ion_min(i)
-   end do
-   if(n_plasma<epsilon)then
-    np_per_xc(1)=0
-    np_per_yc(1)=0
-    n_plasma=zero_dp
-   end if
-  else if(nsp==1)then
-   n_plasma=one_dp
+  if(Wake)then
+    n_plasma=0
+    if(nsp>1)then
+     do i=1,nsp-1
+      n_plasma=n_plasma+concentration(i)*N_mol_atoms(i)*ion_min(i)
+     end do
+     if(n_plasma<epsilon)then
+      np_per_xc(1)=0
+      np_per_yc(1)=0
+      n_plasma=zero_dp
+     end if
+    else if(nsp==1)then
+     n_plasma=one_dp
+    end if
   end if
   ncrit=pi/(rc0*lam0*lam0)      !critical density in units n0=10^21/cm^3=10^9/mu^3
   n0_ref= 1.e03*ncrit*n_over_nc ! reference density in 10^18/cc=10^6/mu^3 unit

--- a/src/grid_and_particles.f90
+++ b/src/grid_and_particles.f90
@@ -33,14 +33,14 @@
  integer :: ibx,iby,ibz
  real(dp) :: k0,yx_rat,zx_rat,djc(3),lxb,lyb
  real(dp) :: ch_opt,fl_opt
- integer :: mp_per_cell(6),nref,nb_laser
+ integer :: mp_per_cell(Ref_nlayer),nref,nb_laser
  integer :: np_per_xc(Ref_nlayer),np_per_yc(Ref_nlayer),np_per_zc(Ref_nlayer),ppc(Ref_nlayer)
- integer :: ion_min(3),ion_max(3),atomic_number(3),ionz_lev,ionz_model
+ integer :: ion_min(Ref_nlayer),ion_max(Ref_nlayer),atomic_number(Ref_nlayer),N_mol_atoms(Ref_nlayer),ionz_lev,ionz_model
  integer :: loc_nyc_max,loc_nzc_max,loc_nxc_max,ndim_max
- real(dp) :: ratio_mpc(6),pavg_npart(4),wgh_ion
+ real(dp) :: ratio_mpc(Ref_nlayer),pavg_npart(4),wgh_ion, concentration(Ref_nlayer)
  real(dp) :: mass(4),mass_rat(4),charge_to_mass(4),unit_charge(4),Lorentz_fact(4)
  real(dp) :: mass_number(3)
- real(dp) :: n0_ref,pmass,ompe,vbeam,curr_max(3),t0_pl(4),j0_norm,ratio_mpfluid,chann_fact
+ real(dp) :: n0_ref,pmass,ompe,vbeam,curr_max(3),t0_pl(4),j0_norm,ratio_mpfluid,chann_fact,n_plasma
  real(dp) :: gam_min,gam0,bet0,u0_b, nb_over_np,b_charge
 
  real(dp) :: t0_lp,xc_lp,xf,w0_x,w0_y,lam0,a0

--- a/src/ionize.f90
+++ b/src/ionize.f90
@@ -270,6 +270,7 @@
     wgh_cmp=spec(ic)%part(n,id_ch)
     charge=-1
     part_ind=-1
+    wgh=wgh*N_mol_atoms(ic)
     do i=1,inc
      ii=ii+1
      spec(1)%part(ii,1:2)=spec(ic)%part(n,1:2)
@@ -334,6 +335,7 @@
     wgh_cmp=spec(ic)%part(n,id_ch)
     charge=-1
     part_ind=-1
+    wgh=wgh*N_mol_atoms(ic)
     do i=1,inc
      ii=ii+1
      spec(1)%part(ii,1:2)=spec(ic)%part(n,1:2)

--- a/src/ionize.f90
+++ b/src/ionize.f90
@@ -270,7 +270,7 @@
     wgh_cmp=spec(ic)%part(n,id_ch)
     charge=-1
     part_ind=-1
-    wgh=wgh*N_mol_atoms(ic)
+    wgh=wgh*N_mol_atoms(ic-1)
     do i=1,inc
      ii=ii+1
      spec(1)%part(ii,1:2)=spec(ic)%part(n,1:2)
@@ -335,7 +335,7 @@
     wgh_cmp=spec(ic)%part(n,id_ch)
     charge=-1
     part_ind=-1
-    wgh=wgh*N_mol_atoms(ic)
+    wgh=wgh*N_mol_atoms(ic-1)
     do i=1,inc
      ii=ii+1
      spec(1)%part(ii,1:2)=spec(ic)%part(n,1:2)

--- a/src/ionz_data.f90
+++ b/src/ionz_data.f90
@@ -88,6 +88,43 @@
  end select
  end subroutine set_atomic_weight
  !================================
+ subroutine set_atoms_per_molecule(At_number,N_mol_atoms)
+ integer,intent(in) :: At_number
+ integer,intent(inout) :: N_mol_atoms
+ !========================================
+ ! This subroutine sets if the neutral gas
+ ! Is mono- or diatomic
+ !========================================
+ select case(At_number)
+ case(1)
+  N_mol_atoms=2    !H
+ case(2)
+  N_mol_atoms=1    !He
+ case(7)
+  N_mol_atoms=2    !N
+ case(8)
+  N_mol_atoms=2    !O
+ case(9)
+  N_mol_atoms=2    !F
+ case(10)
+  N_mol_atoms=1    !Ne
+ case(17)
+  N_mol_atoms=2    !Cl
+ case(18)
+  N_mol_atoms=1    !Ar
+ case(35)
+  N_mol_atoms=2    !Br
+ case(36)
+  N_mol_atoms=1    !Kr
+ case(53)
+  N_mol_atoms=2    !I
+ case(54)
+  N_mol_atoms=1    !Xe
+ case DEFAULT
+ N_mol_atoms=1
+ end select
+ end subroutine set_atoms_per_molecule
+ !================================
  subroutine set_ionization_coeff(An,sp_ionz)
  integer,intent(in) :: An(:),sp_ionz
  integer :: i,j,loc_zm

--- a/src/pic_in.f90
+++ b/src/pic_in.f90
@@ -416,9 +416,10 @@
  integer,intent(in) :: layer_mod,nyh
  real(dp),intent(in) :: xf0
  integer :: p,i,j,i1,i2,ic
- integer :: n_peak,npmax,nxtot
+ integer :: n_peak,npmax,nxtot,len_conc
  real(dp) :: uu,u2,xp_min,xp_max,u3,ramp_prefactor
- real(dp) :: xfsh,un(2),wgh_sp(3)
+ real(dp) :: xfsh,un(2),wgh_sp(nsp)
+ real(dp), allocatable :: conc(:)
  integer :: nxl(6)
  integer :: loc_nptx(4),nps_loc(4),last_particle_index(4),nptx_alloc(4)
  !==========================
@@ -438,6 +439,11 @@
  ! Parameters for particle distribution along the x-coordinate
  !============================
  ! Layers nxl(1:5) all containing the same ion species
+ len_conc=size(concentration)
+ allocate(conc(len_conc))
+ do i=1,len_conc
+  conc(i)=concentration(i)
+ end do
  xtot=0.0
  nxtot=0
  do i=1,6
@@ -473,14 +479,18 @@
  !=====================================================
  ! Longitudinal distribution
  nptx=0
- !Weights for mulpispecies target
- wgh_sp(1:3)=j0_norm
- if(nsp==2)then
-  wgh_sp(2)=1./(real(mp_per_cell(2),dp))
-  if(ion_min(1)>1)wgh_sp(2)=1./(real(ion_min(1),dp)*real(mp_per_cell(2),dp))
- endif
+ !Weights for multispecies target
+ !wgh_sp(1:3)=j0_norm
+ !if(nsp==2)then
+ !wgh_sp(2)=1./(real(mp_per_cell(2),dp))
+ 
+ wgh_sp(1)=n_plasma/real(mp_per_cell(1),dp)
+ do i=2,nsp
+  if(mp_per_cell(i)>0) wgh_sp(i)=one_dp/real(mp_per_cell(i),dp)
+  wgh_sp(i)=conc(i-1)*wgh_sp(i)
+ end do
  select case(layer_mod)
-  !================ first uniform layer np1=================
+ !================ first uniform layer np1=================
  case(1)
   if(nxl(1)>0)then
    ramp_prefactor=one_dp-np1

--- a/src/pic_in.f90
+++ b/src/pic_in.f90
@@ -484,7 +484,7 @@
  !if(nsp==2)then
  !wgh_sp(2)=1./(real(mp_per_cell(2),dp))
  
- wgh_sp(1)=n_plasma/real(mp_per_cell(1),dp)
+ wgh_sp(1)=j0_norm*n_plasma
  do i=2,nsp
   if(mp_per_cell(i)>0) wgh_sp(i)=one_dp/real(mp_per_cell(i),dp)
   wgh_sp(i)=conc(i-1)*wgh_sp(i)
@@ -2502,7 +2502,7 @@
  !=============================
  allocate(fluid_x_profile(nxf))
  !====================
- peak_fluid_density=1.-ratio_mpfluid
+ peak_fluid_density=(one_dp-ratio_mpfluid)*n_plasma
  fluid_x_profile(:)=zero_dp
  fluid_yz_profile(:,:)=one_dp
  np1_loc=0.005

--- a/src/read_input.f90
+++ b/src/read_input.f90
@@ -64,7 +64,7 @@
  NAMELIST/SIMULATION/LPf_ord,der_ord,str_flag,iform,model_id,&
   dmodel_id,ibx,iby,ibz,ibeam,ch_opt,fl_opt
  NAMELIST/TARGET_DESCRIPTION/nsp,nsb,ionz_lev,ionz_model,ion_min,ion_max,atomic_number,&
-  mass_number,t0_pl,ppc,np_per_xc,np_per_yc,np_per_zc,lpx,lpy,incid_angle,&
+  mass_number,t0_pl,ppc,np_per_xc,np_per_yc,np_per_zc,concentration,lpx,lpy,incid_angle,&
   n_over_nc,np1,np2,r_c,L_disable_rng_seed
  NAMELIST/LASER/G_prof,nb_laser,t0_lp,xc_lp,tau_fwhm,w0_y,a0,lam0,lp_delay,&
  lp_offset,t1_lp,tau1_fwhm,w1_y,a1,lam1,Symmetrization_pulse,a_symm_rat,Enable_ionization,&
@@ -309,7 +309,7 @@ end subroutine read_nml_integrated_background_diagnostic
  NAMELIST/SIMULATION/LPf_ord,der_ord,str_flag,iform,model_id,&
   dmodel_id,ibx,iby,ibz,ibeam
  NAMELIST/TARGET_DESCRIPTION/nsp,nsb,ionz_lev,ionz_model,ion_min,ion_max,atomic_number,&
-  mass_number,t0_pl,ppc,np_per_xc,np_per_yc,np_per_zc,lpx,lpy,incid_angle,&
+  mass_number,t0_pl,ppc,np_per_xc,np_per_yc,np_per_zc,concentration,lpx,lpy,incid_angle,&
   n_over_nc,np1,np2,r_c
  NAMELIST/LASER/G_prof,nb_laser,t0_lp,xc_lp,tau_fwhm,w0_y,a0,lam0,lp_delay,&
   lp_offset,t1_lp,tau1_fwhm,w1_y,a1,lam1,Symmetrization_pulse,a_symm_rat,Enable_ionization,&

--- a/src/read_input.f90
+++ b/src/read_input.f90
@@ -104,6 +104,8 @@
  np_per_zc=-1
  L_disable_rng_seed = .false.
  incid_angle=zero_dp
+ concentration(:) = zero_dp
+ concentration(1) = one_dp
  open(nml_iounit,file=input_namelist_filename, status='old')
  read(nml_iounit,TARGET_DESCRIPTION,iostat=nml_ierr)
  nml_error_message='TARGET_DESCRIPTION'


### PR DESCRIPTION
In this PR, ion concentrations are added.
It is now possible to set every species concentration, allowing to describe real gas mixtures. Two cases are now considered:
- if `nsp=1` nothing is changed: `n_over_nc` represents the usual initial plasma density.
- if `nsp>1`, `n_over_nc` represents the density of the neutral background gas, *e.g.* the initial density produced by a supersonic gas jet. The initial plasma density is therefore computed according the initial degree of backgroung ionization. If no atom is already ionized, *i.e.* `ion_min=0` for every ion, no plasma is present and it should be generated by the ionization process. Otherwise, if some initial atomic level is already ionized, the plasma density is computed via `n_p=n_over_nc*Sum( c_i *ion_min(i)*N_i)`, where `c_i` is the *i-th* ion concentration and `N_i` is the number of atoms in the *i-th* species molecule.