### PR TITLE
Fixed CI builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,17 +5,17 @@ cache: C:\Tools\vcpkg\installed\
 environment:
   WORKSPACE: C:\projects
   matrix:
-  - platform: PGI1910
-    COMPILER: pgi
-    GENERATOR: "NMake Makefiles"
-    VCPKG_DEFAULT_TRIPLET: x64-windows
+  - platform: MSYS64
+    COMPILER: msys2
+    BASH: c:\msys64\usr\bin\env MSYSTEM=MINGW64 C:\msys64\usr\bin\bash -lc
   - platform: Cygwin64
     COMPILER: cygwin
     CYGWIN_NOWINPATH: yes
     BASH: C:\cygwin64\bin\bash -c
-  - platform: MSYS64
-    COMPILER: msys2
-    BASH: c:\msys64\usr\bin\env MSYSTEM=MINGW64 C:\msys64\usr\bin\bash -lc
+  - platform: PGI1910
+    COMPILER: pgi
+    GENERATOR: "NMake Makefiles"
+    VCPKG_DEFAULT_TRIPLET: x64-windows
 
 matrix:
   allow_failures:
@@ -109,6 +109,15 @@ install:
   - mkdir cygwin-downloads
   - ps: if($env:COMPILER -eq "cygwin") { Invoke-WebRequest https://cygwin.com/setup-x86_64.exe -OutFile $env:WORKSPACE\cygwin-setup.exe }
   - if [%COMPILER%]==[cygwin] %WORKSPACE%\cygwin-setup.exe --quiet-mode --no-shortcuts --no-startmenu --no-desktop --upgrade-also --root C:\cygwin64 --local-package-dir %WORKSPACE%\cygwin-downloads --packages libopenmpi-devel,cmake,fftw3,libfftw3-devel,libboost-devel,zlib-devel,gcc-fortran
+  # As reported in https://www.msys2.org/news/#2020-06-29-new-packagers, there have been some changes in the MSYS packagers that
+  # may cause errors in the package upgrades.
+  # These should be temporary, implementing this workaround until they are fixed
+  - if [%COMPILER%]==[msys2] %BASH% "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
+  - if [%COMPILER%]==[msys2] %BASH% "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
+  - if [%COMPILER%]==[msys2] %BASH% "pacman -U --noconfirm --config <(echo) msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
+  - if [%COMPILER%]==[msys2] %BASH% "pacman-key --verify msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
+  # End workaround
+  - if [%COMPILER%]==[msys2] %BASH% "pacman -Sy --noconfirm pacman"
   - if [%COMPILER%]==[msys2] %BASH% "pacman -Syu --noconfirm"
   - if [%COMPILER%]==[msys2] %BASH% "pacman -R --noconfirm mingw-w64-x86_64-gcc-ada mingw-w64-x86_64-gcc-objc"
   - if [%COMPILER%]==[msys2] %BASH% "pacman -Sy --noconfirm mingw-w64-x86_64-msmpi mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-gcc-fortran mingw-w64-x86_64-gcc-libgfortran mingw-w64-x86_64-fftw mingw-w64-x86_64-msmpi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
           - gcc
           update: true
       env:
-        - MATRIX_EVAL="FC=/usr/local/bin/gfortran-9"
+        - MATRIX_EVAL="FC=/usr/local/bin/gfortran-10"
 
     - os: osx
       compiler: clang


### PR DESCRIPTION
This PR should hopefully fix the CI errors in the MSYS toolchain and in the macos - gfortran toolchain (now updated to gfortran-10)